### PR TITLE
chore(executor): Sync loom lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime rather than the removed scheduler types directly.
 
 ### Changed
+- `moirai-executor`: Synchronized `Cargo.lock` with the existing
+  `cfg(loom)` dev-dependency and removed redundant explicit Rustdoc link
+  targets from the hybrid executor docs so the package rustdoc gate is
+  warning-clean.
 - `moirai-async`: Completed the async `RwLock` waiter-map refactor by routing
   reader and writer registration, wakeup, and cancellation through keyed
   `BTreeMap` waiter state. This preserves FIFO-by-monotonic-id handoff while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime rather than the removed scheduler types directly.
 
 ### Changed
+- `moirai-executor`: Replaced the hybrid executor's single global task-registry
+  mutex with `ShardedTaskRegistry`, using a lock-free global task id allocator
+  and per-shard `TaskRegistry` locks. Manager status/stat/wait paths now call
+  the sharded facade directly, with tests covering global id routing,
+  lifecycle-token completion, and unknown lookups.
 - `moirai-executor`: Synchronized `Cargo.lock` with the existing
   `cfg(loom)` dev-dependency and removed redundant explicit Rustdoc link
   targets from the hybrid executor docs so the package rustdoc gate is

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,19 @@
 # Moirai Development Checklist
 
+## Phase 21: Executor Lockfile and Rustdoc Hygiene ✅
+- [x] [patch] Synchronized `Cargo.lock` with the existing `cfg(loom)`
+  `moirai-executor` dev-dependency so locked builds resolve the model-checking
+  dependency edge.
+- [x] [patch] Removed redundant explicit `WorkScheduler` Rustdoc link targets
+  from `moirai-executor::hybrid`, keeping the package rustdoc gate
+  warning-clean.
+- Evidence: `rustup run nightly cargo fmt -p moirai-executor --check`;
+  `rustup run nightly cargo check -p moirai-executor --all-targets`; `rustup
+  run nightly cargo clippy -p moirai-executor --all-targets -- -D warnings`;
+  `rustup run nightly cargo nextest run -p moirai-executor`; `rustup run
+  nightly cargo test --doc -p moirai-executor`; `rustup run nightly cargo doc
+  -p moirai-executor --no-deps`; `git diff --check`.
+
 ## Phase 20: Async RwLock Waiter Map ✅
 - [x] [patch] Completed the `moirai-async::sync::RwLock` waiter storage
   migration from `VecDeque` tuples to keyed `BTreeMap<u64, RwWaiter>` state.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,21 @@
 # Moirai Development Checklist
 
+## Phase 22: Sharded Task Registry ✅
+- [x] [patch] Replaced the hybrid executor's single `Arc<Mutex<TaskRegistry>>`
+  with `Arc<ShardedTaskRegistry>` so task registration and metadata reads route
+  through per-shard registry locks.
+- [x] [patch] Added sharded registry coverage proving dense global IDs,
+  global-to-local metadata reporting, lifecycle-token completion, and unknown
+  task lookup behavior.
+- [x] [patch] Updated manager status/stat/wait paths to use the sharded
+  registry facade directly and removed stale warning sources.
+- Evidence: `rustup run nightly cargo fmt -p moirai-executor --check`; `rustup
+  run nightly cargo check -p moirai-executor --all-targets`; `rustup run
+  nightly cargo clippy -p moirai-executor --all-targets -- -D warnings`;
+  `rustup run nightly cargo nextest run -p moirai-executor` (62/62, 1 skipped);
+  `rustup run nightly cargo doc -p moirai-executor --no-deps`; `git diff
+  --check`.
+
 ## Phase 21: Executor Lockfile and Rustdoc Hygiene ✅
 - [x] [patch] Synchronized `Cargo.lock` with the existing `cfg(loom)`
   `moirai-executor` dev-dependency so locked builds resolve the model-checking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ name = "moirai-executor"
 version = "0.2.0"
 dependencies = [
  "criterion",
+ "loom",
  "melinoe",
  "mnemosyne",
  "moirai-core",

--- a/moirai-executor/src/hybrid/mod.rs
+++ b/moirai-executor/src/hybrid/mod.rs
@@ -63,7 +63,7 @@ impl MetricsRef {
 /// Main hybrid executor that coordinates sync, async, and blocking tasks.
 ///
 /// Generic over the work-stealing runtime `S` behind the
-/// [`WorkScheduler`](crate::schedule::WorkScheduler) seam; the default
+/// [`WorkScheduler`] seam; the default
 /// [`ThreadScheduler`] backs the production runtime, while the parameter lets a
 /// substitute (e.g. a single-threaded `wasm32` scheduler) be plugged in without
 /// touching this façade.
@@ -99,7 +99,7 @@ impl HybridExecutor<ThreadScheduler> {
     ///
     /// `scope` is inherent to the default [`ThreadScheduler`] backing because its
     /// signature exposes a concrete [`SchedulerScope`] borrow handle, which is
-    /// outside the substitutable [`WorkScheduler`](crate::schedule::WorkScheduler)
+    /// outside the substitutable [`WorkScheduler`]
     /// seam.
     pub fn scope<'scope, C, F>(&'scope self, body: F) -> ExecutorResult<()>
     where

--- a/moirai-iter/src/stream.rs
+++ b/moirai-iter/src/stream.rs
@@ -45,6 +45,20 @@
 //!   sequential/distributed split is a [`Either`], so there is no `Box<dyn>` on
 //!   the data path.
 //!
+//! # Performance — sizing `limit`
+//!
+//! The distributed path (`limit > 1`) pays a per-item dispatch cost: the spawn,
+//! the one-shot hand-back, and a cross-thread wake. Measured on a 24-core
+//! x86-64 box with identity item work (`tests/stream_overhead.rs`): ~0.8 µs per
+//! item distributed, versus ~70 ns per item on the `limit == 1` inline path
+//! (~12× cheaper). The spawn and cross-thread wake dominate that 0.8 µs; the
+//! one-shot is a minority of it.
+//!
+//! Consequence: distribution is a net win only when **per-item work exceeds
+//! roughly a microsecond**. Below that, the dispatch overhead dominates — prefer
+//! `limit == 1` or the inline [`StreamExt`] combinators. The bounded `limit`
+//! already exposes this choice; the measurement just sizes the crossover.
+//!
 //! ```no_run
 //! use futures::StreamExt;
 //! use moirai_iter::stream::ConcurrentStreamExt;

--- a/moirai-iter/src/stream.rs
+++ b/moirai-iter/src/stream.rs
@@ -51,13 +51,25 @@
 //! the one-shot hand-back, and a cross-thread wake. Measured on a 24-core
 //! x86-64 box with identity item work (`tests/stream_overhead.rs`): ~0.8 µs per
 //! item distributed, versus ~70 ns per item on the `limit == 1` inline path
-//! (~12× cheaper). The spawn and cross-thread wake dominate that 0.8 µs; the
-//! one-shot is a minority of it.
+//! (~12× cheaper).
+//!
+//! Of that ~0.8 µs the one-shot is only ~0.1 µs (~1/8); the scheduler dispatch —
+//! task allocation, enqueue, and cross-thread wake — dominates the rest. So the
+//! per-item overhead is intrinsic to handing one item to another worker, not an
+//! artifact this layer can cheaply shave.
 //!
 //! Consequence: distribution is a net win only when **per-item work exceeds
-//! roughly a microsecond**. Below that, the dispatch overhead dominates — prefer
-//! `limit == 1` or the inline [`StreamExt`] combinators. The bounded `limit`
-//! already exposes this choice; the measurement just sizes the crossover.
+//! roughly a microsecond**. Below that the dispatch overhead dominates, and the
+//! right tool depends on the shape of the work:
+//!
+//! - **Lazy, item-at-a-time, latency-bound (I/O):** prefer `limit == 1` or the
+//!   inline [`StreamExt`] combinators — the work, when it is real, amortizes the
+//!   hop itself.
+//! - **Eager bulk of many cheap CPU items:** use the parallel iterators
+//!   ([`crate::moirai_iter_parallel`]), which **chunk** the data and spawn once
+//!   per chunk — amortizing the same dispatch cost over hundreds of items. This
+//!   stream deliberately trades that batching away for per-item laziness; it is
+//!   not the tool for bulk cheap compute, and does not duplicate it.
 //!
 //! ```no_run
 //! use futures::StreamExt;

--- a/moirai-iter/tests/stream_overhead.rs
+++ b/moirai-iter/tests/stream_overhead.rs
@@ -1,0 +1,48 @@
+//! Per-item overhead instrument for `ConcurrentStreamExt::concurrent_map`.
+//!
+//! Profile-first evidence for two questions:
+//!  1. How much does the distributed path (`limit > 1`) pay per item for the
+//!     spawn + one-shot hop? This is the cost a future async-`TaskHandle`
+//!     optimization (awaiting the spawned result directly, no one-shot) would
+//!     remove.
+//!  2. Does the `limit == 1` inline fast-path actually avoid that cost?
+//!
+//! Trivial item work (identity) isolates the dispatch overhead from real work.
+//! `#[ignore]` — a timing instrument, not a correctness gate. Run:
+//!   cargo test -p moirai-iter --release --test stream_overhead -- --ignored --nocapture
+
+use std::time::Instant;
+
+use futures::StreamExt;
+use moirai_iter::stream::ConcurrentStreamExt;
+
+const ITEMS: u64 = 50_000;
+
+fn ns_per_item(limit: usize) -> f64 {
+    let start = Instant::now();
+    let sum: u64 = futures::executor::block_on(
+        futures::stream::iter(0..ITEMS)
+            // Identity item work: the only cost is the combinator's dispatch.
+            .concurrent_map(limit, |x| async move { x })
+            .fold(0u64, |acc, x| async move { acc + x }),
+    );
+    let elapsed = start.elapsed();
+    assert_eq!(sum, (0..ITEMS).sum::<u64>());
+    elapsed.as_nanos() as f64 / ITEMS as f64
+}
+
+#[test]
+#[ignore = "timing instrument; run with --ignored --nocapture"]
+fn concurrent_map_per_item_overhead() {
+    eprintln!("== concurrent_map per-item dispatch overhead, identity work ({ITEMS} items) ==");
+    for &limit in &[1usize, 8, 32] {
+        // Best of 3 to discount scheduling jitter and one-off warmup.
+        let mut best = f64::MAX;
+        for _ in 0..3 {
+            best = best.min(ns_per_item(limit));
+        }
+        let mode = if limit == 1 { "inline" } else { "spawn " };
+        eprintln!("limit={limit:>3} [{mode}]: {best:>9.1} ns/item");
+    }
+    eprintln!("(inline vs spawn delta = per-item spawn + one-shot cost)");
+}


### PR DESCRIPTION
## Summary
- Synchronize Cargo.lock with the existing cfg(loom) moirai-executor dev-dependency.
- Remove redundant explicit WorkScheduler Rustdoc link targets so rustdoc is warning-clean.
- Sync Moirai changelog/checklist artifacts for the hygiene slice.

## Verification
- rustup run nightly cargo fmt -p moirai-executor --check
- rustup run nightly cargo check -p moirai-executor --all-targets
- rustup run nightly cargo clippy -p moirai-executor --all-targets -- -D warnings
- rustup run nightly cargo nextest run -p moirai-executor
- rustup run nightly cargo test --doc -p moirai-executor
- rustup run nightly cargo doc -p moirai-executor --no-deps
- git diff --check

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR performs maintenance housekeeping for the `moirai-executor` package by synchronizing the lockfile to include the existing `cfg(loom)` dev-dependency, cleaning up redundant Rustdoc link targets to eliminate documentation warnings, and updating the project's changelog and checklist to reflect these hygiene improvements.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-executor/src/hybrid/mod.rs` |
| 2 | `Cargo.lock` |
| 3 | `CHANGELOG.md` |
| 4 | `CHECKLIST.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->