### PR TITLE
refactor(iter): dedup ReduceWithConsumer into ReduceConsumer

### DIFF
--- a/moirai-iter/src/parallel.rs
+++ b/moirai-iter/src/parallel.rs
@@ -40,5 +40,5 @@ pub use traits::{
 
 use consumers::{
     CollectConsumer, FilterConsumer, FindConsumer, InspectConsumer, MapConsumer, NullConsumer,
-    ReduceConsumer, ReduceWithConsumer,
+    ReduceConsumer,
 };

--- a/moirai-iter/src/parallel/consumers.rs
+++ b/moirai-iter/src/parallel/consumers.rs
@@ -119,6 +119,11 @@ where
     }
 }
 
+/// Parallel associative-reduce consumer: collects each shard's items, reduces
+/// them left-to-right, and combines partial `Reduction`s in shard order. Single
+/// SSOT backing both the `reduce` and `reduce_with` terminals — their contracts
+/// (associative `Fn(Item, Item) -> Item`, `Option` result, `None` on empty) are
+/// identical, so they share this one combine path rather than duplicating it.
 pub struct ReduceConsumer<F> {
     reduce_fn: F,
 }
@@ -246,52 +251,6 @@ where
 
     fn combine(left: Self::Result, right: Self::Result) -> Self::Result {
         left.or(right)
-    }
-}
-
-pub struct ReduceWithConsumer<F> {
-    reduce_fn: F,
-}
-
-impl<F> ReduceWithConsumer<F> {
-    pub(super) fn new(reduce_fn: F) -> Self {
-        Self { reduce_fn }
-    }
-}
-
-impl<F, T> Consumer<T> for ReduceWithConsumer<F>
-where
-    F: Fn(T, T) -> T + Send + Sync + Clone,
-    T: Send + Sync + Clone,
-{
-    type Result = Reduction<T, F>;
-
-    fn consume<I>(self, iter: I) -> Self::Result
-    where
-        I: ParallelIterator<Item = T>,
-    {
-        let data: Vec<T> = iter.drive(CollectConsumer::new());
-
-        let reduce_fn = self.reduce_fn;
-        let value = data.into_iter().reduce(&reduce_fn);
-        Reduction::new(value, reduce_fn)
-    }
-
-    fn split_at(self, _index: usize) -> (Self, Self) {
-        (
-            ReduceWithConsumer::new(self.reduce_fn.clone()),
-            ReduceWithConsumer::new(self.reduce_fn),
-        )
-    }
-
-    fn combine(left: Self::Result, right: Self::Result) -> Self::Result {
-        let reduce_fn = left.reduce_fn;
-        let value = match (left.value, right.value) {
-            (Some(left), Some(right)) => Some(reduce_fn(left, right)),
-            (Some(value), None) | (None, Some(value)) => Some(value),
-            (None, None) => None,
-        };
-        Reduction::new(value, reduce_fn)
     }
 }
 

--- a/moirai-iter/src/parallel/tests.rs
+++ b/moirai-iter/src/parallel/tests.rs
@@ -1238,4 +1238,19 @@ proptest::proptest! {
             proptest::prop_assert!(valid);
         }
     }
+
+    /// `reduce_with` carries the same associative-combine contract as `reduce`
+    /// and must equal the sequential `Iterator::reduce` for any input (`None` on
+    /// empty). The two methods now drive one shared `ReduceConsumer`; this pins
+    /// the public `reduce_with` surface to an independent sequential oracle so a
+    /// future re-divergence of the two terminals cannot silently regress its
+    /// value semantics.
+    #[test]
+    fn prop_reduce_with_matches_sequential(
+        data in proptest::collection::vec(proptest::prelude::any::<u64>(), 0..600),
+    ) {
+        let par = data.clone().into_par_iter().reduce_with(|a, b| a.wrapping_add(b));
+        let seq = data.into_iter().reduce(|a, b| a.wrapping_add(b));
+        proptest::prop_assert_eq!(par, seq);
+    }
 }

--- a/moirai-iter/src/parallel/traits.rs
+++ b/moirai-iter/src/parallel/traits.rs
@@ -2,8 +2,8 @@ use super::{fallible, split, TryStreamItem};
 use super::{
     Chain, Chunks, Cloned, CollectConsumer, Copied, Enumerate, Filter, FilterMap, FindConsumer,
     FlatMap, Flatten, Inspect, Intersperse, Map, MapInit, MapWith, NullConsumer, PanicFuse,
-    Positions, ReduceConsumer, ReduceWithConsumer, Reduction, Rev, SequentialAdapter, Skip,
-    SkipAnyWhile, Take, TakeAnyWhile, Update, WhileSome, Zip, ZipEq,
+    Positions, ReduceConsumer, Reduction, Rev, SequentialAdapter, Skip, SkipAnyWhile, Take,
+    TakeAnyWhile, Update, WhileSome, Zip, ZipEq,
 };
 
 /// Core parallel iterator trait for Moirai's Rayon-style non-indexed subset.
@@ -569,7 +569,7 @@ pub trait ParallelIterator: Sized + Send {
         F: Fn(Self::Item, Self::Item) -> Self::Item + Send + Sync + Clone,
         Self::Item: Sync + Clone,
     {
-        let reduction: Reduction<Self::Item, F> = self.drive(ReduceWithConsumer::new(reduce_fn));
+        let reduction: Reduction<Self::Item, F> = self.drive(ReduceConsumer::new(reduce_fn));
         reduction.into_value()
     }
 


### PR DESCRIPTION
`ReduceWithConsumer` was a **byte-for-byte duplicate** of `ReduceConsumer` — identical `consume`/`split_at`/`combine`, differing only in the struct name. Both back terminals with the same contract (associative `Fn(Item,Item)->Item`, `Option` result, `None` on empty), so `reduce_with` now drives the single `ReduceConsumer` and the duplicate struct + `Consumer` impl are removed.

- **Non-breaking**: `mod consumers` is private and consumers are imported (not `pub use`) — internal detail, no public API change. Both public methods `reduce`/`reduce_with` are preserved.
- **SSOT** for the parallel reduce-combine path (subtractive: consumers.rs −46 lines).
- **Guarded**: new `prop_reduce_with_matches_sequential` pins the public `reduce_with` surface against the sequential `Iterator::reduce` oracle so the shared path cannot silently regress value semantics.

## Verification
- `cargo build/fmt --check/clippy --all-targets --all-features -D warnings`: clean
- `cargo nextest run -p moirai-iter --all-features`: **204/204** (incl. new proptest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes code duplication by consolidating `ReduceWithConsumer` and `ReduceConsumer` into a single implementation. Both structs were byte-for-byte identical with the same `consume`, `split_at`, and `combine` logic, differing only in name. The `reduce_with` method now uses the unified `ReduceConsumer`, eliminating 46 lines of duplicate code. A new property-based test verifies that `reduce_with` continues to match sequential `Iterator::reduce` behavior, ensuring the refactor preserves correctness.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-iter/src/parallel/consumers.rs` |
| 2 | `moirai-iter/src/parallel/traits.rs` |
| 3 | `moirai-iter/src/parallel.rs` |
| 4 | `moirai-iter/src/parallel/tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->