### PR TITLE
fix(ipc): Capture platform error portably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `moirai-core`: read the thread-local operating-system error through
+  `std::io::Error` on Unix and Windows, removing the Linux-only errno symbol
+  that prevented IPC consumers from compiling on macOS.
+
 ### Added
 - `moirai-executor`: added `block_on`, a public current-thread parking wait
   primitive over the existing scheduler waker driver. This gives Moirai-owned

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,6 +8,8 @@ admitted work across the hierarchy the stack actually owns: local CPU worker
 threads, supervised processes, per-process async lanes, server routes, and future
 accelerator routes. Rayon/Tokio parity remains a regression gate, not the
 architecture definition.
+- [x] [patch] Make IPC error capture portable across Unix and Windows so Atlas
+  consumers compile the shared-memory provider on Linux, macOS, and Windows.
 - [~] [minor] Stage B1 rayon parity: `join(a,b)` divide-and-conquer shorthand
   delivered through `moirai_parallel::{join, join_with}` with static
   `ExecutionPolicy` dispatch, scoped scheduler flush plus caller-lane execution

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -11,6 +11,9 @@
 
 ## Remaining Gap Register
 
+- [x] [patch] Replace the Linux-only IPC errno accessor with the portable
+  standard-library contract; focused IPC nextest coverage passes 9/9 and
+  warning-denied `moirai-core` clippy is clean.
 - [x] [patch] Add Apollo-facing public `moirai` crate contract tests for chunked
   mutable scheduling and caller-owned indexed collection. The tests verify
   complete disjoint element coverage and non-`Clone` movement into existing

--- a/moirai-core/src/ipc/error.rs
+++ b/moirai-core/src/ipc/error.rs
@@ -26,23 +26,11 @@ impl fmt::Display for IpcError {
 
 impl core::error::Error for IpcError {}
 
-/// Convert OS error to `IpcError`
-#[cfg(unix)]
+/// Convert the calling thread's last operating-system error to `IpcError`.
+#[cfg(any(unix, windows))]
 pub fn last_os_error() -> IpcError {
-    unsafe { IpcError::SystemError(*libc::__errno_location()) }
-}
-
-/// Convert OS error to `IpcError`
-#[cfg(windows)]
-pub fn last_os_error() -> IpcError {
-    extern "system" {
-        fn GetLastError() -> u32;
-    }
-    // SAFETY: `GetLastError` takes no arguments and reads thread-local state.
-    // justification: the Win32 error code is carried verbatim in an `i32` field;
-    // the `u32 -> i32` reinterpretation preserves all bits (no value is lost).
-    #[allow(clippy::cast_possible_wrap)]
-    unsafe {
-        IpcError::SystemError(GetLastError() as i32)
-    }
+    let code = std::io::Error::last_os_error()
+        .raw_os_error()
+        .expect("invariant: last_os_error captures a raw operating-system error code");
+    IpcError::SystemError(code)
 }


### PR DESCRIPTION
## Summary
- replace the Linux-only errno accessor with std::io::Error::last_os_error
- preserve the raw platform error code without unsafe platform FFI
- synchronize the Moirai backlog, checklist, and changelog

## Verification
- cargo clippy -p moirai-core --all-features -- -D warnings
- cargo nextest run -p moirai-core ipc (9/9)
- rustfmt check on the touched source

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a portability issue in the IPC error handling code by replacing a Linux-specific errno accessor with the standard library's `std::io::Error::last_os_error()` method. The change eliminates platform-specific FFI calls and enables the IPC module to compile across Unix (including macOS) and Windows platforms. Documentation files (changelog, backlog, and checklist) are updated to reflect this fix.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-core/src/ipc/error.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->