### PR TITLE
fix(reactor): Isolate kqueue event storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `moirai-core`: read the thread-local operating-system error through
   `std::io::Error` on Unix and Windows, removing the Linux-only errno symbol
   that prevented IPC consumers from compiling on macOS.
+- `moirai-pal`: keep the pointer-bearing kqueue output buffer thread-local, so
+  the reactor remains `Send + Sync` without an unsafe marker implementation or
+  a per-poll allocation.
 
 ### Added
 - `moirai-executor`: added `block_on`, a public current-thread parking wait

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,6 +8,8 @@ admitted work across the hierarchy the stack actually owns: local CPU worker
 threads, supervised processes, per-process async lanes, server routes, and future
 accelerator routes. Rayon/Tokio parity remains a regression gate, not the
 architecture definition.
+- [x] [patch] Preserve kqueue reactor thread safety with a per-thread reusable
+  event buffer rather than storing libc pointer-bearing events in shared state.
 - [x] [patch] Make IPC error capture portable across Unix and Windows so Atlas
   consumers compile the shared-memory provider on Linux, macOS, and Windows.
 - [~] [minor] Stage B1 rayon parity: `join(a,b)` divide-and-conquer shorthand

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -11,6 +11,8 @@
 
 ## Remaining Gap Register
 
+- [x] [patch] Confine kqueue event storage to each polling thread, preserving
+  allocation-free reuse while satisfying the reactor's `Send + Sync` contract.
 - [x] [patch] Replace the Linux-only IPC errno accessor with the portable
   standard-library contract; focused IPC nextest coverage passes 9/9 and
   warning-denied `moirai-core` clippy is clean.

--- a/moirai-pal/src/unix/kqueue.rs
+++ b/moirai-pal/src/unix/kqueue.rs
@@ -1,6 +1,7 @@
 //! kqueue reactor for macOS and BSD targets.
 
 use std::{
+    cell::RefCell,
     collections::HashMap,
     io, ptr,
     sync::{Mutex, MutexGuard},
@@ -12,13 +13,17 @@ use crate::{Event, Interest, RawFd, Reactor};
 const EVENT_CAPACITY: usize = 1024;
 const WAKE_IDENT: usize = usize::MAX;
 
+thread_local! {
+    /// Per-poller output storage keeps the hot poll path allocation-free while
+    /// confining libc's pointer-bearing `kevent` representation to its thread.
+    static EVENT_BUFFER: RefCell<Vec<libc::kevent>> =
+        RefCell::new(vec![zeroed_event(); EVENT_CAPACITY]);
+}
+
 /// kqueue-backed reactor for BSD-style event notification.
 pub struct KqueueReactor {
     kqueue_fd: RawFd,
     interests: Mutex<HashMap<RawFd, Interest>>,
-    /// Reused `kevent` output buffer (`EVENT_CAPACITY` entries), so the hot
-    /// poll loop does not allocate a fresh 1024-entry vector per iteration.
-    events: Mutex<Vec<libc::kevent>>,
 }
 
 impl KqueueReactor {
@@ -34,7 +39,6 @@ impl KqueueReactor {
         let reactor = Self {
             kqueue_fd,
             interests: Mutex::new(HashMap::new()),
-            events: Mutex::new(vec![zeroed_event(); EVENT_CAPACITY]),
         };
         reactor.register_waker()?;
         Ok(reactor)
@@ -92,48 +96,50 @@ impl Reactor for KqueueReactor {
     }
 
     fn poll_events(&self, timeout: Option<Duration>) -> io::Result<Vec<Event>> {
-        // Reuse the persistent output buffer; the mutex serializes concurrent
-        // pollers (the reactor is driven by one event-loop thread in practice).
-        let mut events = lock_mutex(&self.events);
-        let timeout_spec = timeout.map(duration_to_timespec);
-        let timeout_ptr = timeout_spec
-            .as_ref()
-            .map_or(ptr::null(), |spec| spec as *const libc::timespec);
+        EVENT_BUFFER.with(|buffer| {
+            let mut events = buffer.try_borrow_mut().map_err(|_| {
+                io::Error::other("kqueue polling cannot re-enter on the same thread")
+            })?;
+            let timeout_spec = timeout.map(duration_to_timespec);
+            let timeout_ptr = timeout_spec
+                .as_ref()
+                .map_or(ptr::null(), |spec| spec as *const libc::timespec);
 
-        // Safety: `events` points to writable storage for `EVENT_CAPACITY`
-        // entries. `timeout_ptr` is either null or points to a stack timespec
-        // valid for the duration of the syscall.
-        let ready = unsafe {
-            libc::kevent(
-                self.kqueue_fd,
-                ptr::null(),
-                0,
-                events.as_mut_ptr(),
-                EVENT_CAPACITY as i32,
-                timeout_ptr,
-            )
-        };
+            // Safety: `events` points to writable storage for `EVENT_CAPACITY`
+            // entries. `timeout_ptr` is either null or points to a stack timespec
+            // valid for the duration of the syscall.
+            let ready = unsafe {
+                libc::kevent(
+                    self.kqueue_fd,
+                    ptr::null(),
+                    0,
+                    events.as_mut_ptr(),
+                    EVENT_CAPACITY as i32,
+                    timeout_ptr,
+                )
+            };
 
-        if ready < 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        let mut output = Vec::with_capacity(ready as usize);
-        for event in events.iter().take(ready as usize) {
-            if event.ident == WAKE_IDENT {
-                continue;
+            if ready < 0 {
+                return Err(io::Error::last_os_error());
             }
 
-            output.push(Event {
-                fd: event.ident as RawFd,
-                readable: event.filter == libc::EVFILT_READ,
-                writable: event.filter == libc::EVFILT_WRITE,
-                error: (event.flags & libc::EV_ERROR) != 0,
-                hangup: (event.flags & libc::EV_EOF) != 0,
-            });
-        }
+            let mut output = Vec::with_capacity(ready as usize);
+            for event in events.iter().take(ready as usize) {
+                if event.ident == WAKE_IDENT {
+                    continue;
+                }
 
-        Ok(output)
+                output.push(Event {
+                    fd: event.ident as RawFd,
+                    readable: event.filter == libc::EVFILT_READ,
+                    writable: event.filter == libc::EVFILT_WRITE,
+                    error: (event.flags & libc::EV_ERROR) != 0,
+                    hangup: (event.flags & libc::EV_EOF) != 0,
+                });
+            }
+
+            Ok(output)
+        })
     }
 
     fn wake(&self) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- move pointer-bearing kqueue output entries from shared reactor state to per-thread storage
- preserve allocation-free buffer reuse without unsafe Send/Sync marker implementations
- retain explicit re-entrant poll failure and synchronize Moirai PM artifacts

## Verification
- cargo fmt -p moirai-pal -- --check
- cargo clippy -p moirai-pal --all-features -- -D warnings
- cargo nextest run -p moirai-pal (22/22)
- macOS compile verification is delegated to the consuming RITK matrix

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR moves the kqueue event buffer from shared reactor state to thread-local storage, ensuring the reactor remains `Send + Sync` without requiring unsafe marker implementations. The change preserves allocation-free buffer reuse by using a `thread_local!` macro with `RefCell` wrapper, while adding re-entrant poll detection to prevent same-thread concurrent polling attempts. This fix resolves a thread safety issue where the pointer-bearing `libc::kevent` entries were previously stored in shared state.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-pal/src/unix/kqueue.rs` |
| 2 | `CHANGELOG.md` |
| 3 | `docs/checklist.md` |
| 4 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->