### PR TITLE
fix(executor): Flatten caller nested regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `moirai-executor`: flatten worker-nested indexed regions onto the current lane,
   preserving outer parallelism without recursively stealing outer jobs onto the
   worker stack.
+- `moirai-executor`: track indexed-region depth on the participating caller so
+  its nested fan-out and reductions also flatten onto the outer caller lane.
 - `moirai-executor`: distribute indexed remainders across every selected lane
   instead of leaving worker lanes unused when the item count is just above the
   worker-plus-caller cap.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,5 +1,17 @@
 # Moirai Development Checklist
 
+## Phase 29: Indexed caller-region flattening
+
+- [x] [patch] Mark the caller lane while it participates in indexed fan-out
+  and map/reduce so nested regions flatten on every outer lane, not only
+  scheduler workers.
+- [x] Verify exact caller/worker lane identity and value sums through nextest,
+  then run warning-denied Clippy.
+- [ ] Pin the commit in RITK and pass the unchanged masked-CMA consumer gate.
+- Evidence: `cargo nextest run -p moirai-executor` passed 83/83 with one
+  cfg-gated skip; warning-denied all-target/all-feature Clippy passed. The RITK
+  consumer gate follows after pinning this commit.
+
 ## Phase 28: Melinoe executor capability migration
 
 - [x] [major] Construct Melinoe's validated `ParallelExecutor` next to the real

--- a/moirai-executor/src/schedule/runtime/scheduler/data_parallel.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/data_parallel.rs
@@ -19,7 +19,8 @@ use moirai_core::{
 
 use super::super::super::{class::WorkClass, reduce::ReduceSlots};
 use super::super::types::{
-    get_current_worker_id, SchedulerScopeState, SharedScopedTaskCompletion, ThreadScheduler,
+    get_current_worker_id, is_in_indexed_region, IndexedRegionGuard, SchedulerScopeState,
+    SharedScopedTaskCompletion, ThreadScheduler,
 };
 use super::super::worker::{
     indexed_chunk_bounds, indexed_chunk_count, inline_map_reduce, map_reduce_range,
@@ -58,7 +59,7 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
         // A worker already contributes one lane of outer parallelism. Flatten
         // nested indexed regions on that lane: recursively stealing unrelated
         // outer jobs grows the worker stack with every nested tensor reduction.
-        if get_current_worker_id().is_some() {
+        if get_current_worker_id().is_some() || is_in_indexed_region() {
             return catch_unwind(AssertUnwindSafe(|| {
                 for index in 0..count {
                     task(index);
@@ -71,6 +72,7 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
         let (_, caller_end) = indexed_chunk_bounds(count, chunk_count, 0);
         if chunk_count == 1 {
             return catch_unwind(AssertUnwindSafe(|| {
+                let _region = IndexedRegionGuard::enter();
                 for index in 0..caller_end {
                     task(index);
                 }
@@ -112,6 +114,7 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
 
         let caller_result = if schedule_result.is_ok() {
             catch_unwind(AssertUnwindSafe(|| {
+                let _region = IndexedRegionGuard::enter();
                 for index in 0..caller_end {
                     task(index);
                 }
@@ -162,13 +165,14 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
             return Ok(identity);
         }
 
-        if get_current_worker_id().is_some() {
+        if get_current_worker_id().is_some() || is_in_indexed_region() {
             return inline_map_reduce(count, identity, map, reduce);
         }
 
         let chunk_count = indexed_chunk_count(count, self.worker_count());
         let (_, caller_end) = indexed_chunk_bounds(count, chunk_count, 0);
         if chunk_count == 1 {
+            let _region = IndexedRegionGuard::enter();
             return inline_map_reduce(count, identity, map, reduce);
         }
 
@@ -209,6 +213,7 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
 
         let caller_result = if schedule_result.is_ok() {
             catch_unwind(AssertUnwindSafe(|| {
+                let _region = IndexedRegionGuard::enter();
                 map_reduce_range(0, caller_end, identity.clone(), map, reduce)
             }))
             .map_err(|_| ExecutorError::SpawnFailed(moirai_core::error::TaskError::Panicked))

--- a/moirai-executor/src/schedule/runtime/tests.rs
+++ b/moirai-executor/src/schedule/runtime/tests.rs
@@ -596,6 +596,58 @@ fn nested_indexed_saturation_completes() {
 }
 
 #[test]
+fn indexed_caller_flattens_nested_regions_onto_its_lane() {
+    const WORKERS: usize = 2;
+    const OUTER_ITEMS: usize = WORKERS + 1;
+    const INNER_ITEMS: usize = 32;
+    let scheduler = ThreadScheduler::new(WORKERS, "test-indexed-caller-nesting").unwrap();
+    let visited = AtomicUsize::new(0);
+    let reduced = AtomicUsize::new(0);
+
+    scheduler
+        .for_each_indexed::<SyncTask, _>(Priority::Normal, None, OUTER_ITEMS, |outer_index| {
+            let outer_lane = get_current_worker_id();
+            scheduler
+                .for_each_indexed::<SyncTask, _>(
+                    Priority::Normal,
+                    None,
+                    INNER_ITEMS,
+                    |inner_index| {
+                        assert_eq!(get_current_worker_id(), outer_lane);
+                        visited.fetch_add(
+                            outer_index * INNER_ITEMS + inner_index + 1,
+                            Ordering::Relaxed,
+                        );
+                    },
+                )
+                .expect("nested indexed fan-out must remain on its outer lane");
+
+            let local_sum = scheduler
+                .map_reduce_indexed::<SyncTask, _, _, _>(
+                    Priority::Normal,
+                    None,
+                    INNER_ITEMS,
+                    0usize,
+                    |inner_index| {
+                        assert_eq!(get_current_worker_id(), outer_lane);
+                        outer_index * INNER_ITEMS + inner_index + 1
+                    },
+                    usize::wrapping_add,
+                )
+                .expect("nested indexed reduction must remain on its outer lane");
+            reduced.fetch_add(local_sum, Ordering::Relaxed);
+        })
+        .unwrap();
+
+    let item_count = OUTER_ITEMS * INNER_ITEMS;
+    let expected = item_count * (item_count + 1) / 2;
+    assert_eq!(visited.load(Ordering::Relaxed), expected);
+    assert_eq!(reduced.load(Ordering::Relaxed), expected);
+    scheduler.join().unwrap();
+    scheduler.shutdown();
+}
+
+#[test]
 fn indexed_map_reduce_small_count_schedules_worker_lanes() {
     let scheduler = ThreadScheduler::new(2, "test-indexed-reduce-small").unwrap();
 
@@ -639,7 +691,9 @@ fn indexed_map_reduce_reports_panicked_mapper() {
 
     scheduler.shutdown();
     assert_eq!(result, Err(ExecutorError::SpawnFailed(TaskError::Panicked)));
-    assert_eq!(metrics.completed_tasks, 1);
+    // Four indices use the caller plus two scheduled chunks. Both scheduled
+    // tasks reach terminal completion even though one reports a mapper panic.
+    assert_eq!(metrics.completed_tasks, 2);
 }
 
 #[test]

--- a/moirai-executor/src/schedule/runtime/types.rs
+++ b/moirai-executor/src/schedule/runtime/types.rs
@@ -250,6 +250,11 @@ melinoe::thread_cached! {
     pub(super) mod current_worker_id: usize;
 }
 
+melinoe::thread_cached! {
+    /// Indexed-region nesting depth for a participating non-worker caller.
+    mod indexed_region_depth: usize;
+}
+
 #[inline(always)]
 pub(super) fn get_current_worker_id() -> Option<usize> {
     current_worker_id::get()
@@ -261,6 +266,36 @@ pub(super) fn set_current_worker_id(id: Option<usize>) {
         current_worker_id::set(val);
     } else {
         current_worker_id::clear();
+    }
+}
+
+pub(super) fn is_in_indexed_region() -> bool {
+    indexed_region_depth::get().is_some_and(|depth| depth > 0)
+}
+
+pub(super) struct IndexedRegionGuard {
+    previous_depth: Option<usize>,
+}
+
+impl IndexedRegionGuard {
+    pub(super) fn enter() -> Self {
+        let previous_depth = indexed_region_depth::get();
+        let depth = previous_depth
+            .unwrap_or(0)
+            .checked_add(1)
+            .expect("invariant: indexed-region nesting depth fits usize");
+        indexed_region_depth::set(depth);
+        Self { previous_depth }
+    }
+}
+
+impl Drop for IndexedRegionGuard {
+    fn drop(&mut self) {
+        if let Some(depth) = self.previous_depth {
+            indexed_region_depth::set(depth);
+        } else {
+            indexed_region_depth::clear();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- track indexed-region depth on the participating caller lane
- flatten nested fan-out and map/reduce on caller and worker lanes
- assert exact lane identity and value sums across caller-plus-worker execution

## Verification
- cargo nextest run -p moirai-executor: 83 passed, 1 cfg-gated skip
- warning-denied all-target/all-feature Clippy passed

RITK consumer driver: ryancinsight/ritk#30

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes nested indexed region execution by tracking the depth of indexed regions on participating caller threads. When a caller thread participates in indexed fan-out or map/reduce operations, any nested indexed operations now flatten onto that same caller lane instead of creating recursive parallelism. This prevents the worker stack from growing with every nested operation. The implementation adds an `IndexedRegionGuard` RAII type to mark caller participation and checks both worker ID and indexed region depth before deciding whether to flatten or parallelize nested operations.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-executor/src/schedule/runtime/types.rs` |
| 2 | `moirai-executor/src/schedule/runtime/scheduler/data_parallel.rs` |
| 3 | `moirai-executor/src/schedule/runtime/tests.rs` |
| 4 | `CHANGELOG.md` |
| 5 | `CHECKLIST.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nested indexed operations now remain on the originating execution lane, improving flattening behavior and preventing unnecessary recursive scheduling.
  * Indexed fan-out and reduction results now maintain consistent execution and completion tracking, including when a mapper encounters an error.

* **Tests**
  * Added coverage verifying nested indexed operations produce correct lane assignment and calculated results.
  * Updated scheduler completion checks for panicking mapper scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->