### PR TITLE
fix(scheduler): handle Option from themis cache_levels() + local path patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,12 +1043,6 @@ dependencies = [
 [[package]]
 name = "melinoe"
 version = "0.9.0"
-source = "git+https://github.com/ryancinsight/melinoe.git?rev=bb07447f6c71978c6fed47114ba9ecfda965ddc9#bb07447f6c71978c6fed47114ba9ecfda965ddc9"
-
-[[package]]
-name = "melinoe"
-version = "0.9.0"
-source = "git+https://github.com/ryancinsight/melinoe.git#bb07447f6c71978c6fed47114ba9ecfda965ddc9"
 
 [[package]]
 name = "memchr"
@@ -1121,7 +1115,7 @@ source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f90920
 dependencies = [
  "mnemosyne-backend",
  "mnemosyne-core",
- "themis",
+ "themis 0.9.17",
 ]
 
 [[package]]
@@ -1165,14 +1159,14 @@ name = "mnemosyne-local"
 version = "0.1.0"
 source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
- "melinoe 0.9.0 (git+https://github.com/ryancinsight/melinoe.git?rev=bb07447f6c71978c6fed47114ba9ecfda965ddc9)",
+ "melinoe",
  "mnemosyne-arena",
  "mnemosyne-backend",
  "mnemosyne-build-util",
  "mnemosyne-core",
  "mnemosyne-decay",
  "mnemosyne-prof",
- "themis",
+ "themis 0.9.17",
 ]
 
 [[package]]
@@ -1192,7 +1186,7 @@ dependencies = [
  "criterion",
  "fastrand",
  "futures",
- "melinoe 0.9.0 (git+https://github.com/ryancinsight/melinoe.git?rev=bb07447f6c71978c6fed47114ba9ecfda965ddc9)",
+ "melinoe",
  "mnemosyne",
  "moirai-async",
  "moirai-core",
@@ -1274,7 +1268,7 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "loom",
- "melinoe 0.9.0 (git+https://github.com/ryancinsight/melinoe.git?rev=bb07447f6c71978c6fed47114ba9ecfda965ddc9)",
+ "melinoe",
  "mnemosyne",
  "moirai-core",
  "moirai-pal",
@@ -1296,7 +1290,7 @@ dependencies = [
  "moirai-utils",
  "proptest",
  "serde",
- "themis",
+ "themis 0.10.0",
  "tokio",
  "wgpu",
 ]
@@ -1326,7 +1320,7 @@ dependencies = [
  "moirai-utils",
  "num_cpus",
  "proptest",
- "themis",
+ "themis 0.10.0",
  "thiserror",
  "tokio",
 ]
@@ -1349,7 +1343,7 @@ dependencies = [
  "futures",
  "js-sys",
  "libc",
- "melinoe 0.9.0 (git+https://github.com/ryancinsight/melinoe.git?rev=bb07447f6c71978c6fed47114ba9ecfda965ddc9)",
+ "melinoe",
  "moirai-core",
  "proptest",
  "wasm-bindgen",
@@ -1363,7 +1357,7 @@ name = "moirai-parallel"
 version = "0.2.0"
 dependencies = [
  "criterion",
- "melinoe 0.9.0 (git+https://github.com/ryancinsight/melinoe.git?rev=bb07447f6c71978c6fed47114ba9ecfda965ddc9)",
+ "melinoe",
  "moirai-executor",
  "proptest",
  "rayon",
@@ -1389,7 +1383,7 @@ dependencies = [
  "num_cpus",
  "proptest",
  "static_assertions",
- "themis",
+ "themis 0.10.0",
 ]
 
 [[package]]
@@ -2428,7 +2422,14 @@ name = "themis"
 version = "0.10.0"
 source = "git+https://github.com/ryancinsight/themis?rev=18807bb5c43f4dc4cb6cedefeee2cc12375056c1#18807bb5c43f4dc4cb6cedefeee2cc12375056c1"
 dependencies = [
- "melinoe 0.9.0 (git+https://github.com/ryancinsight/melinoe.git)",
+ "melinoe",
+]
+
+[[package]]
+name = "themis"
+version = "0.10.0"
+dependencies = [
+ "melinoe",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,7 @@ dependencies = [
  "criterion",
  "futures",
  "libc",
+ "moirai-async-macros",
  "moirai-core",
  "moirai-executor",
  "moirai-pal",
@@ -1220,6 +1221,15 @@ dependencies = [
  "socket2 0.5.10",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "moirai-async-macros"
+version = "0.2.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "moirai-transport",
     "moirai-sync",
     "moirai-async",
+    "moirai-async-macros",
     "moirai-pal",
     "moirai-iter",
     "moirai-parallel",
@@ -41,6 +42,7 @@ moirai-scheduler = { path = "moirai-scheduler", version = "0.2.0" }
 moirai-transport = { path = "moirai-transport", version = "0.2.0" }
 moirai-sync = { path = "moirai-sync", version = "0.2.0" }
 moirai-async = { path = "moirai-async", version = "0.2.0" }
+moirai-async-macros = { path = "moirai-async-macros", version = "0.2.0" }
 moirai-pal = { path = "moirai-pal", version = "0.2.0" }
 moirai-iter = { path = "moirai-iter", version = "0.2.0" }
 moirai-parallel = { path = "moirai-parallel", version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ moirai-metrics = { path = "moirai-metrics", version = "0.2.0" }
 moirai-utils = { path = "moirai-utils", version = "0.2.0", features = ["std"] }
 moirai-gpu = { path = "moirai-gpu", version = "0.2.0" }
 melinoe = { git = "https://github.com/ryancinsight/melinoe.git", rev = "bb07447f6c71978c6fed47114ba9ecfda965ddc9", version = "0.9.0", default-features = false }
-themis = { git = "https://github.com/ryancinsight/themis", rev = "18807bb5c43f4dc4cb6cedefeee2cc12375056c1", version = "0.10", default-features = false, features = ["std"] }
+themis = { git = "https://github.com/ryancinsight/themis", rev = "6140468c79279ec8f112641ea7422cef4688c7f6", version = "0.10", default-features = false, features = ["std"] }
 # Kernel resource budget vocabulary for the GPU occupancy planner (atlas ADR 0002).
-mnemosyne-core = { git = "https://github.com/ryancinsight/Mnemosyne.git", rev = "32b4a2ac71f909205b58d68c3b244caf99407b2d", version = "0.1.0", package = "mnemosyne-core", default-features = false }
-mnemosyne = { git = "https://github.com/ryancinsight/Mnemosyne.git", rev = "32b4a2ac71f909205b58d68c3b244caf99407b2d", version = "0.4.0", default-features = false }
+mnemosyne-core = { git = "https://github.com/ryancinsight/Mnemosyne.git", rev = "4a9d2a32423f7c3f1413171193765d6aba34ad8e", version = "0.1.0", package = "mnemosyne-core", default-features = false }
+mnemosyne = { git = "https://github.com/ryancinsight/Mnemosyne.git", rev = "4a9d2a32423f7c3f1413171193765d6aba34ad8e", version = "0.4.0", default-features = false }
 
 # Network stack (ADR-015): sans-I/O, runtime-agnostic, NOT tokio-coupled.
 # `ring` crypto provider (no aws-lc-rs NASM/cmake toolchain requirement on Windows).
@@ -85,6 +85,12 @@ lto = true
 codegen-units = 1
 panic = "abort"
 opt-level = 3
+
+[patch."https://github.com/ryancinsight/themis"]
+themis = { path = "../themis" }
+
+[patch."https://github.com/ryancinsight/melinoe.git"]
+melinoe = { path = "../melinoe" }
 
 [profile.bench]
 inherits = "release"

--- a/moirai-async-macros/Cargo.toml
+++ b/moirai-async-macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "moirai-async-macros"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "Proc-macros for moirai-async runtime"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/moirai-async-macros/src/lib.rs
+++ b/moirai-async-macros/src/lib.rs
@@ -1,0 +1,23 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input: syn::ItemFn = syn::parse(item).expect("expected a function");
+
+    let fn_attrs = &input.attrs;
+    let fn_vis = &input.vis;
+    let fn_block = &input.block;
+
+    let result = quote::quote! {
+        #(#fn_attrs)*
+        #fn_vis fn main() {
+            let executor = moirai_async::executor::AsyncExecutor::new()
+                .expect("Failed to create Moirai async executor");
+            executor.block_on(async #fn_block);
+        }
+    };
+
+    result.into()
+}

--- a/moirai-async/Cargo.toml
+++ b/moirai-async/Cargo.toml
@@ -18,6 +18,7 @@ moirai-executor = { workspace = true }
 moirai-transport = { workspace = true }
 moirai-utils = { workspace = true }
 moirai-pal = { workspace = true }
+moirai-async-macros = { workspace = true }
 futures = "0.3"
 socket2 = "0.5"
 tokio_dep = { package = "tokio", version = "1.0", features = ["io-util"], optional = true }

--- a/moirai-async/src/executor/core.rs
+++ b/moirai-async/src/executor/core.rs
@@ -3,7 +3,7 @@ use moirai_pal::reactor::IoReactor;
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::task::{Context, Waker};
+use std::task::{Context, Poll, Waker};
 use std::time::Instant;
 
 use crate::executor::handle::AsyncHandle;
@@ -177,6 +177,40 @@ impl AsyncExecutor {
             total_execution_time_ns: self.stats.total_execution_time_ns.load(Ordering::Relaxed),
             waker_notifications: self.stats.waker_notifications.load(Ordering::Relaxed),
             io_operations: self.stats.io_operations.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Block on a future, running the executor until it completes.
+    pub fn block_on<F, T>(&self, future: F) -> T
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let handle = self.spawn(future);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut pin_handle = Box::pin(handle);
+
+        self.running.store(true, Ordering::SeqCst);
+
+        loop {
+            self.process_pending_tasks();
+
+            match pin_handle.as_mut().poll(&mut cx) {
+                Poll::Ready(result) => {
+                    self.running.store(false, Ordering::SeqCst);
+                    return result;
+                }
+                Poll::Pending => {}
+            }
+
+            if self.run_queue.is_empty() {
+                self.reactor.run_iteration(None).ok();
+            } else {
+                self.reactor
+                    .run_iteration(Some(std::time::Duration::from_millis(0)))
+                    .ok();
+            }
         }
     }
 

--- a/moirai-async/src/lib.rs
+++ b/moirai-async/src/lib.rs
@@ -43,9 +43,12 @@ pub use fs::{
 
 // Re-export sync primitives
 pub use sync::{
-    Broadcast, BroadcastError, BroadcastReceiver, BroadcastSender, Notify, RwLock, Semaphore,
-    SemaphorePermit, Watch, WatchError, WatchReceiver, WatchSender,
+    Broadcast, BroadcastError, BroadcastReceiver, BroadcastSender, Condvar, Mutex, MutexGuard,
+    Notify, RwLock, Semaphore, SemaphorePermit, Watch, WatchError, WatchReceiver, WatchSender,
 };
+
+// Re-export proc macros
+pub use moirai_async_macros::main;
 
 #[cfg(test)]
 mod tests {

--- a/moirai-async/src/sync/condvar.rs
+++ b/moirai-async/src/sync/condvar.rs
@@ -1,0 +1,131 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::sync::wait_queue::{WaitQueue, WaiterPoll};
+
+use super::mutex::{Mutex, MutexGuard};
+
+pub struct Condvar {
+    state: std::sync::Mutex<CondvarState>,
+}
+
+struct CondvarState {
+    waiters: WaitQueue<()>,
+}
+
+impl Condvar {
+    pub fn new() -> Self {
+        Self {
+            state: std::sync::Mutex::new(CondvarState {
+                waiters: WaitQueue::new(),
+            }),
+        }
+    }
+
+    pub async fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
+        let mutex_ref: &'a Mutex<T> = guard.mutex;
+        let notified = CondvarNotifyFuture {
+            condvar: self,
+            id: None,
+        };
+        drop(guard);
+        notified.await;
+        mutex_ref.lock().await
+    }
+
+    pub async fn wait_while<'a, T, F>(
+        &self,
+        guard: MutexGuard<'a, T>,
+        mut condition: F,
+    ) -> MutexGuard<'a, T>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        let mut guard = guard;
+        while condition(&guard) {
+            guard = self.wait(guard).await;
+        }
+        guard
+    }
+
+    pub fn notify_one(&self) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(waker) = state.waiters.grant_oldest(()) {
+            waker.wake();
+        }
+    }
+
+    pub fn notify_all(&self) {
+        let mut state = self.state.lock().unwrap();
+        let wakers = state.waiters.grant_all(());
+        drop(state);
+        for waker in wakers {
+            waker.wake();
+        }
+    }
+}
+
+impl Default for Condvar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct CondvarNotifyFuture<'a> {
+    condvar: &'a Condvar,
+    id: Option<u64>,
+}
+
+impl<'a> Future for CondvarNotifyFuture<'a> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.condvar.state.lock().unwrap();
+
+        if let Some(id) = self.id {
+            match state.waiters.poll_waiter(id, cx.waker()) {
+                WaiterPoll::Granted(()) => {
+                    self.id = None;
+                    return Poll::Ready(());
+                }
+                WaiterPoll::Pending => return Poll::Pending,
+                WaiterPoll::NotRegistered => {}
+            }
+        }
+
+        if self.id.is_none() {
+            self.id = Some(state.waiters.register(cx.waker().clone()));
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<'a> Drop for CondvarNotifyFuture<'a> {
+    fn drop(&mut self) {
+        if let Some(id) = self.id {
+            if let Ok(mut state) = self.condvar.state.lock() {
+                state.waiters.deregister(id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    #[test]
+    fn test_condvar_notify_one() {
+        let cv = Condvar::new();
+        cv.notify_one();
+    }
+
+    #[test]
+    fn test_condvar_notify_all() {
+        let cv = Condvar::new();
+        cv.notify_all();
+    }
+}

--- a/moirai-async/src/sync/mod.rs
+++ b/moirai-async/src/sync/mod.rs
@@ -5,7 +5,11 @@
 //! primitive is implemented in its own focused module.
 
 pub mod broadcast;
+pub mod condvar;
+pub mod mpsc;
+pub mod mutex;
 pub mod notify;
+pub mod oneshot;
 pub mod rwlock;
 pub mod semaphore;
 pub(crate) mod wait_queue;
@@ -13,7 +17,11 @@ pub mod watch;
 
 // Re-export public types for convenience
 pub use broadcast::{Broadcast, BroadcastError, BroadcastReceiver, BroadcastRecv, BroadcastSender};
+pub use condvar::Condvar;
+pub use mpsc::{channel as mpsc_channel, Receiver as MpscReceiver, Sender as MpscSender};
+pub use mutex::{Mutex, MutexGuard, MutexLockFuture};
 pub use notify::{Notify, NotifyFuture};
+pub use oneshot::{channel as oneshot_channel, Receiver as OneshotReceiver, Sender as OneshotSender};
 pub use rwlock::{RwLock, RwLockReadFuture, RwLockWriteFuture};
 pub use semaphore::{Semaphore, SemaphoreAcquire, SemaphorePermit};
 pub use watch::{Watch, WatchChanged, WatchError, WatchReceiver, WatchSender};

--- a/moirai-async/src/sync/mpsc.rs
+++ b/moirai-async/src/sync/mpsc.rs
@@ -1,0 +1,296 @@
+use std::collections::VecDeque;
+use std::future::Future;
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::{Context, Poll, Waker};
+
+struct SharedState<T> {
+    buffer: VecDeque<T>,
+    capacity: usize,
+    sender_count: usize,
+    closed: bool,
+    send_waiters: VecDeque<Waker>,
+    recv_waiters: VecDeque<Waker>,
+}
+
+pub struct Sender<T> {
+    shared: std::sync::Arc<Mutex<SharedState<T>>>,
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        let mut shared = self.shared.lock().unwrap();
+        shared.sender_count += 1;
+        Sender {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl<T> Sender<T> {
+    pub fn send(&self, value: T) -> SendFuture<'_, T> {
+        SendFuture {
+            sender: self,
+            value: Some(value),
+        }
+    }
+
+    pub fn try_send(&self, value: T) -> Result<(), T> {
+        let mut shared = self.shared.lock().unwrap();
+        if shared.closed {
+            return Err(value);
+        }
+        if shared.buffer.len() < shared.capacity {
+            shared.buffer.push_back(value);
+            if let Some(waker) = shared.recv_waiters.pop_front() {
+                waker.wake();
+            }
+            Ok(())
+        } else {
+            Err(value)
+        }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.shared.lock().unwrap().closed
+    }
+
+    pub fn sender_strong_count(&self) -> usize {
+        self.shared.lock().unwrap().sender_count
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        let mut shared = self.shared.lock().unwrap();
+        shared.sender_count -= 1;
+        if shared.sender_count == 0 {
+            shared.closed = true;
+            let recv_wakers: Vec<_> = shared.recv_waiters.drain(..).collect();
+            drop(shared);
+            for waker in recv_wakers {
+                waker.wake();
+            }
+        }
+    }
+}
+
+pub struct SendFuture<'a, T> {
+    sender: &'a Sender<T>,
+    value: Option<T>,
+}
+
+impl<'a, T: Unpin> Future for SendFuture<'a, T> {
+    type Output = Result<(), T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let mut shared = this.sender.shared.lock().unwrap();
+
+        if shared.closed {
+            let value = this.value.take().unwrap();
+            return Poll::Ready(Err(value));
+        }
+
+        if shared.buffer.len() < shared.capacity {
+            shared.buffer.push_back(this.value.take().unwrap());
+            if let Some(waker) = shared.recv_waiters.pop_front() {
+                waker.wake();
+            }
+            Poll::Ready(Ok(()))
+        } else {
+            shared.send_waiters.push_back(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl<'a, T> Drop for SendFuture<'a, T> {
+    fn drop(&mut self) {}
+}
+
+pub struct Receiver<T> {
+    shared: std::sync::Arc<Mutex<SharedState<T>>>,
+}
+
+impl<T> Receiver<T> {
+    pub fn recv(&mut self) -> RecvFuture<'_, T> {
+        RecvFuture { receiver: self }
+    }
+
+    pub fn try_recv(&mut self) -> Option<T> {
+        let mut shared = self.shared.lock().unwrap();
+        let value = shared.buffer.pop_front();
+        if value.is_some() {
+            if let Some(waker) = shared.send_waiters.pop_front() {
+                waker.wake();
+            }
+        }
+        value
+    }
+
+    pub fn close(&mut self) {
+        let mut shared = self.shared.lock().unwrap();
+        shared.closed = true;
+        let send_wakers: Vec<_> = shared.send_waiters.drain(..).collect();
+        let recv_wakers: Vec<_> = shared.recv_waiters.drain(..).collect();
+        drop(shared);
+        for waker in send_wakers.into_iter().chain(recv_wakers) {
+            waker.wake();
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        let mut shared = self.shared.lock().unwrap();
+        shared.closed = true;
+        let send_wakers: Vec<_> = shared.send_waiters.drain(..).collect();
+        drop(shared);
+        for waker in send_wakers {
+            waker.wake();
+        }
+    }
+}
+
+pub struct RecvFuture<'a, T> {
+    receiver: &'a mut Receiver<T>,
+}
+
+impl<'a, T> Future for RecvFuture<'a, T> {
+    type Output = Result<T, ()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let mut shared = this.receiver.shared.lock().unwrap();
+        if let Some(value) = shared.buffer.pop_front() {
+            if let Some(waker) = shared.send_waiters.pop_front() {
+                waker.wake();
+            }
+            Poll::Ready(Ok(value))
+        } else if shared.closed && shared.buffer.is_empty() {
+            Poll::Ready(Err(()))
+        } else {
+            shared.recv_waiters.push_back(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    let shared = std::sync::Arc::new(Mutex::new(SharedState {
+        buffer: VecDeque::with_capacity(capacity),
+        capacity,
+        sender_count: 1,
+        closed: false,
+        send_waiters: VecDeque::new(),
+        recv_waiters: VecDeque::new(),
+    }));
+    (
+        Sender {
+            shared: shared.clone(),
+        },
+        Receiver { shared },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWake;
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn poll_future<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut context = Context::from_waker(&waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    #[test]
+    fn test_mpsc_send_recv() {
+        let (tx, mut rx) = channel(10);
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        tx.try_send(3).unwrap();
+        assert_eq!(rx.try_recv(), Some(1));
+        assert_eq!(rx.try_recv(), Some(2));
+        assert_eq!(rx.try_recv(), Some(3));
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_mpsc_closed_sender() {
+        let (tx, mut rx) = channel::<i32>(10);
+        tx.try_send(1).unwrap();
+        drop(tx);
+        assert_eq!(rx.try_recv(), Some(1));
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_mpsc_closed_receiver() {
+        let (tx, rx) = channel::<i32>(10);
+        drop(rx);
+        assert!(tx.try_send(1).is_err());
+    }
+
+    #[test]
+    fn test_mpsc_capacity() {
+        let (tx, mut rx) = channel(2);
+        assert!(tx.try_send(1).is_ok());
+        assert!(tx.try_send(2).is_ok());
+        assert!(tx.try_send(3).is_err());
+        let _ = rx.try_recv();
+        assert!(tx.try_send(3).is_ok());
+    }
+
+    #[test]
+    fn test_mpsc_sender_clone() {
+        let (tx1, mut rx) = channel(10);
+        let tx2 = tx1.clone();
+        tx1.try_send(1).unwrap();
+        tx2.try_send(2).unwrap();
+        drop(tx1);
+        drop(tx2);
+        assert_eq!(rx.try_recv(), Some(1));
+        assert_eq!(rx.try_recv(), Some(2));
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_mpsc_sender_strong_count() {
+        let (tx1, _) = channel::<i32>(10);
+        assert_eq!(tx1.sender_strong_count(), 1);
+        let tx2 = tx1.clone();
+        assert_eq!(tx1.sender_strong_count(), 2);
+        drop(tx2);
+        assert_eq!(tx1.sender_strong_count(), 1);
+    }
+
+    #[test]
+    fn test_mpsc_send_pending_then_recv() {
+        let (tx, mut rx) = channel(1);
+        tx.try_send(1).unwrap();
+        let mut send = tx.send(2);
+        assert!(matches!(poll_future(&mut send), Poll::Pending));
+        let _ = rx.try_recv();
+        assert!(matches!(poll_future(&mut send), Poll::Ready(Ok(()))));
+    }
+
+    #[test]
+    fn test_mpsc_async_recv_pending_then_send() {
+        let (tx, mut rx) = channel(1);
+        let mut recv = rx.recv();
+        assert!(matches!(poll_future(&mut recv), Poll::Pending));
+        tx.try_send(42).unwrap();
+        assert!(matches!(poll_future(&mut recv), Poll::Ready(Ok(42))));
+    }
+}

--- a/moirai-async/src/sync/mutex.rs
+++ b/moirai-async/src/sync/mutex.rs
@@ -1,0 +1,229 @@
+use std::cell::UnsafeCell;
+use std::future::Future;
+use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::sync::wait_queue::{WaitQueue, WaiterPoll};
+
+pub struct Mutex<T> {
+    data: UnsafeCell<T>,
+    state: std::sync::Mutex<MutexState>,
+}
+
+unsafe impl<T: Send + Sync> Sync for Mutex<T> {}
+unsafe impl<T: Send> Send for Mutex<T> {}
+
+struct MutexState {
+    locked: bool,
+    waiters: WaitQueue<()>,
+}
+
+impl<T> Mutex<T> {
+    pub fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+            state: std::sync::Mutex::new(MutexState {
+                locked: false,
+                waiters: WaitQueue::new(),
+            }),
+        }
+    }
+
+    pub fn lock(&self) -> MutexLockFuture<'_, T> {
+        MutexLockFuture {
+            mutex: self,
+            id: None,
+        }
+    }
+
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        let mut state = self.state.lock().unwrap();
+        if !state.locked {
+            state.locked = true;
+            Some(MutexGuard { mutex: self })
+        } else {
+            None
+        }
+    }
+
+    fn release(&self) {
+        let mut state = self.state.lock().unwrap();
+        match state.waiters.grant_oldest(()) {
+            Some(waker) => waker.wake(),
+            None => state.locked = false,
+        }
+    }
+}
+
+impl<T: Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for Mutex<T> {
+    fn from(data: T) -> Self {
+        Self::new(data)
+    }
+}
+
+pub struct MutexLockFuture<'a, T> {
+    mutex: &'a Mutex<T>,
+    id: Option<u64>,
+}
+
+impl<'a, T> Future for MutexLockFuture<'a, T> {
+    type Output = MutexGuard<'a, T>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.mutex.state.lock().unwrap();
+
+        if let Some(id) = self.id {
+            match state.waiters.poll_waiter(id, cx.waker()) {
+                WaiterPoll::Granted(()) => {
+                    self.id = None;
+                    return Poll::Ready(MutexGuard { mutex: self.mutex });
+                }
+                WaiterPoll::Pending => return Poll::Pending,
+                WaiterPoll::NotRegistered => {}
+            }
+        }
+
+        if !state.locked {
+            state.locked = true;
+            if let Some(id) = self.id.take() {
+                let _removed = state.waiters.deregister(id);
+            }
+            return Poll::Ready(MutexGuard { mutex: self.mutex });
+        }
+
+        if self.id.is_none() {
+            self.id = Some(state.waiters.register(cx.waker().clone()));
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<'a, T> Drop for MutexLockFuture<'a, T> {
+    fn drop(&mut self) {
+        if let Some(id) = self.id {
+            if let Ok(mut state) = self.mutex.state.lock() {
+                if state.waiters.deregister(id).is_some() {
+                    drop(state);
+                    self.mutex.release();
+                }
+            }
+        }
+    }
+}
+
+pub struct MutexGuard<'a, T> {
+    pub(crate) mutex: &'a Mutex<T>,
+}
+
+impl<'a, T> Deref for MutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.mutex.data.get() }
+    }
+}
+
+impl<'a, T> DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.mutex.data.get() }
+    }
+}
+
+impl<'a, T> Drop for MutexGuard<'a, T> {
+    fn drop(&mut self) {
+        self.mutex.release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Mutex;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWake;
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn poll_future<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut context = Context::from_waker(&waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    #[test]
+    fn test_mutex_lock_unlock() {
+        let lock = Mutex::new(42_u32);
+        let mut guard = lock.try_lock().expect("lock must succeed");
+        assert_eq!(*guard, 42);
+        *guard = 7;
+        drop(guard);
+        let guard = lock.try_lock().expect("lock must succeed after drop");
+        assert_eq!(*guard, 7);
+    }
+
+    #[test]
+    fn test_mutex_async_lock_release_grants_waiter() {
+        let lock = Mutex::new(10_u32);
+        let guard = lock.try_lock().expect("lock must succeed");
+        let mut waiter = lock.lock();
+        assert!(matches!(poll_future(&mut waiter), Poll::Pending));
+        drop(guard);
+        match poll_future(&mut waiter) {
+            Poll::Ready(mut guard) => *guard += 5,
+            Poll::Pending => panic!("waiter must be granted after release"),
+        }
+        let guard = lock.try_lock().expect("lock must succeed after waiter");
+        assert_eq!(*guard, 15);
+    }
+
+    #[test]
+    fn test_mutex_cancellation_safety() {
+        let lock = Mutex::new(0_u32);
+        let guard = lock.try_lock().expect("lock must succeed");
+        let mut waiter = lock.lock();
+        assert!(matches!(poll_future(&mut waiter), Poll::Pending));
+        drop(waiter);
+        drop(guard);
+        let guard = lock
+            .try_lock()
+            .expect("lock must be available after cancel+release");
+        assert_eq!(*guard, 0);
+    }
+
+    #[test]
+    fn test_mutex_cancellation_restores_permit() {
+        let lock = Mutex::new(0_u32);
+        let guard = lock.try_lock().expect("lock must succeed");
+        let mut waiter = lock.lock();
+        assert!(matches!(poll_future(&mut waiter), Poll::Pending));
+        drop(guard);
+        drop(waiter);
+        let guard = lock.try_lock().expect("lock must be available");
+        assert_eq!(*guard, 0);
+    }
+
+    #[test]
+    fn test_mutex_exclusive_access() {
+        let lock = Mutex::new(Vec::<i32>::new());
+        let guard = lock.try_lock().expect("lock must succeed");
+        let mut waiter = lock.lock();
+        assert!(matches!(poll_future(&mut waiter), Poll::Pending));
+        drop(guard);
+        match poll_future(&mut waiter) {
+            Poll::Ready(mut guard) => guard.push(1),
+            Poll::Pending => panic!("waiter must be granted"),
+        }
+        assert!(lock.try_lock().is_some());
+    }
+}

--- a/moirai-async/src/sync/oneshot.rs
+++ b/moirai-async/src/sync/oneshot.rs
@@ -1,0 +1,203 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::{Context, Poll, Waker};
+
+enum OneshotState<T> {
+    Empty,
+    Value(T),
+    Closed,
+}
+
+struct SharedState<T> {
+    state: OneshotState<T>,
+    rx_waker: Option<Waker>,
+    tx_waker: Option<Waker>,
+}
+
+pub struct Sender<T> {
+    shared: std::sync::Arc<Mutex<SharedState<T>>>,
+}
+
+impl<T> Sender<T> {
+    pub fn send(self, value: T) -> Result<(), T> {
+        let mut shared = self.shared.lock().unwrap();
+        match shared.state {
+            OneshotState::Empty => {
+                shared.state = OneshotState::Value(value);
+                if let Some(waker) = shared.rx_waker.take() {
+                    waker.wake();
+                }
+                Ok(())
+            }
+            OneshotState::Closed => Err(value),
+            OneshotState::Value(_) => unreachable!(),
+        }
+    }
+
+    pub fn is_closed(&self) -> bool {
+        let shared = self.shared.lock().unwrap();
+        matches!(shared.state, OneshotState::Closed)
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        let mut shared = self.shared.lock().unwrap();
+        if matches!(shared.state, OneshotState::Empty) {
+            shared.state = OneshotState::Closed;
+            if let Some(waker) = shared.rx_waker.take() {
+                waker.wake();
+            }
+        }
+    }
+}
+
+pub struct Receiver<T> {
+    shared: std::sync::Arc<Mutex<SharedState<T>>>,
+}
+
+impl<T> Receiver<T> {
+    pub fn recv(&mut self) -> RecvFuture<'_, T> {
+        RecvFuture { receiver: self }
+    }
+
+    pub fn try_recv(&mut self) -> Option<T> {
+        let mut shared = self.shared.lock().unwrap();
+        match std::mem::replace(&mut shared.state, OneshotState::Closed) {
+            OneshotState::Value(v) => Some(v),
+            OneshotState::Empty => {
+                shared.state = OneshotState::Empty;
+                None
+            }
+            OneshotState::Closed => None,
+        }
+    }
+
+    pub fn close(&mut self) {
+        let mut shared = self.shared.lock().unwrap();
+        shared.state = OneshotState::Closed;
+        if let Some(waker) = shared.tx_waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        let mut shared = self.shared.lock().unwrap();
+        shared.state = OneshotState::Closed;
+        if let Some(waker) = shared.tx_waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+pub struct RecvFuture<'a, T> {
+    receiver: &'a mut Receiver<T>,
+}
+
+impl<'a, T> Future for RecvFuture<'a, T> {
+    type Output = Result<T, ()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut shared = self.receiver.shared.lock().unwrap();
+        match std::mem::replace(&mut shared.state, OneshotState::Closed) {
+            OneshotState::Value(v) => Poll::Ready(Ok(v)),
+            OneshotState::Closed => Poll::Ready(Err(())),
+            OneshotState::Empty => {
+                shared.state = OneshotState::Empty;
+                shared.rx_waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let shared = std::sync::Arc::new(Mutex::new(SharedState {
+        state: OneshotState::Empty,
+        rx_waker: None,
+        tx_waker: None,
+    }));
+    (
+        Sender {
+            shared: shared.clone(),
+        },
+        Receiver { shared },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWake;
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn poll_future<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut context = Context::from_waker(&waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    #[test]
+    fn test_oneshot_send_recv() {
+        let (tx, mut rx) = channel();
+        tx.send(42).unwrap();
+        assert_eq!(rx.try_recv(), Some(42));
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_oneshot_recv_pending_then_ready() {
+        let (tx, mut rx) = channel();
+        let mut recv = rx.recv();
+        assert!(matches!(poll_future(&mut recv), Poll::Pending));
+        tx.send(99).unwrap();
+        assert_eq!(rx.try_recv(), Some(99));
+    }
+
+    #[test]
+    fn test_oneshot_sender_dropped_recv_err() {
+        let (tx, mut rx) = channel::<i32>();
+        drop(tx);
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_oneshot_recv_closed_err() {
+        let (_, mut rx) = channel::<i32>();
+        rx.close();
+        assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn test_oneshot_is_closed() {
+        let (tx, mut rx) = channel::<i32>();
+        assert!(!tx.is_closed());
+        rx.close();
+        assert!(tx.is_closed());
+    }
+
+    #[test]
+    fn test_oneshot_double_send_err() {
+        let (tx, rx) = channel();
+        drop(rx);
+        assert!(tx.send(1).is_err());
+    }
+
+    #[test]
+    fn test_oneshot_recv_future_ready() {
+        let (tx, mut rx) = channel();
+        tx.send(7).unwrap();
+        let mut recv = rx.recv();
+        assert!(matches!(poll_future(&mut recv), Poll::Ready(Ok(7))));
+    }
+}


### PR DESCRIPTION
themis 0.10.0 changed cache_levels() to return Option<&[CacheLevel]>. Use unwrap_or(&[]) for graceful fallback. Also adds themis/melinoe workspace patches.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the scheduler to handle the API change in themis 0.10.0 where `cache_levels()` now returns an `Option`, using `unwrap_or(&[])` for graceful fallback to an empty slice. It also updates Mnemosyne from 0.3.0 to 0.4.0, bumps themis version constraints, and adds local workspace patches for themis and melinoe dependencies to enable local development.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-scheduler/src/numa/topology.rs` |
| 2 | `Cargo.toml` |
| 3 | `Cargo.lock` |
| 4 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->