### PR TITLE
fix(sync): Linearize resource pool clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   facade and its duplicate backend type identity from integrated consumers.
 
 ### Fixed
+- `moirai-sync`: make `ShardedResourcePool::clear` linearizable with
+  reservation and publication by retaining per-bin guards through counter
+  reset; add a deterministic cross-thread regression for the interleaving.
 - `moirai-core`: re-read the SPSC publication index after acquiring sender
   closure so a value published immediately before sender drop is drained rather
   than misreported as a closed empty channel.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -157,10 +157,11 @@ architecture definition.
   behavioral comparisons, not production dependencies. ADR required.
 - **Evidence tier**: deductive starvation construction; runtime test pending.
 
-#### ✅ ISSUE-214 [patch]: Make resource-pool clear linearizable
+#### ⏳ ISSUE-214 [patch]: Make resource-pool clear linearizable
 - **Owner**: codex; **Scope**: `moirai-sync/src/sync/resource_pool.rs`,
   co-located resource-pool tests/benchmarks, and this PM section.
-- **Status**: done on `codex/moirai-resource-clear-linearizable`.
+- **Status**: review on `codex/moirai-resource-clear-linearizable`; local gates
+  pass, PR #70 has an errored `recurseml/analysis` check and pending review.
 - **Type**: Resource Accounting / Concurrency Correctness
 - **Root Cause**: recycle reserves atomic counters before bin insertion while
   clear drains bins and independently stores counters to zero. A clear between
@@ -171,7 +172,8 @@ architecture definition.
   counter consistency; the fix does not add one shard-wide lock acquisition to
   every steady-state take/recycle.
 - **Evidence tier**: deductive interleaving proof plus value-semantic nextest,
-  warning-denied Clippy, rustdoc, doctest, and Criterion evidence.
+  warning-denied Clippy, rustdoc, doctest, and Criterion evidence; provider CI
+  review remains open.
 #### ✅ ISSUE-217 [patch]: Honor forced indexed parallelism under nesting
 - **Type**: Scheduler correctness / consumer performance
 - **Root Cause**: the scheduler applied an undocumented 256-index grain floor

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -158,6 +158,9 @@ architecture definition.
 - **Evidence tier**: deductive starvation construction; runtime test pending.
 
 #### ⏳ ISSUE-214 [patch]: Make resource-pool clear linearizable
+- **Owner**: codex; **Scope**: `moirai-sync/src/sync/resource_pool.rs`,
+  co-located resource-pool tests/benchmarks, and this PM section.
+- **Status**: in-progress on `codex/moirai-resource-clear-linearizable`.
 - **Type**: Resource Accounting / Concurrency Correctness
 - **Root Cause**: recycle reserves atomic counters before bin insertion while
   clear drains bins and independently stores counters to zero. A clear between

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -157,10 +157,10 @@ architecture definition.
   behavioral comparisons, not production dependencies. ADR required.
 - **Evidence tier**: deductive starvation construction; runtime test pending.
 
-#### ⏳ ISSUE-214 [patch]: Make resource-pool clear linearizable
+#### ✅ ISSUE-214 [patch]: Make resource-pool clear linearizable
 - **Owner**: codex; **Scope**: `moirai-sync/src/sync/resource_pool.rs`,
   co-located resource-pool tests/benchmarks, and this PM section.
-- **Status**: in-progress on `codex/moirai-resource-clear-linearizable`.
+- **Status**: done on `codex/moirai-resource-clear-linearizable`.
 - **Type**: Resource Accounting / Concurrency Correctness
 - **Root Cause**: recycle reserves atomic counters before bin insertion while
   clear drains bins and independently stores counters to zero. A clear between
@@ -170,7 +170,8 @@ architecture definition.
   between recycle reservation and insertion, then proves exact retrieval and
   counter consistency; the fix does not add one shard-wide lock acquisition to
   every steady-state take/recycle.
-- **Evidence tier**: deductive interleaving proof; runtime test pending.
+- **Evidence tier**: deductive interleaving proof plus value-semantic nextest,
+  warning-denied Clippy, rustdoc, doctest, and Criterion evidence.
 #### ✅ ISSUE-217 [patch]: Honor forced indexed parallelism under nesting
 - **Type**: Scheduler correctness / consumer performance
 - **Root Cause**: the scheduler applied an undocumented 256-index grain floor

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -26,6 +26,8 @@
       steady-state Criterion baseline. `resource_pool/recycle_take` median is
       28.088 ns with a 27.984–28.190 ns confidence interval; no speedup claim
       is made without a same-machine pre-change comparator.
+- [ ] Provider PR #70 has a clean CI/review result and is merged before the
+      Atlas gitlink advances.
 
 Acceptance: `clear` has a linearizable boundary with `recycle` and `take`,
 steady-state operations acquire no new shard-wide lock, and no resource can

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -13,6 +13,22 @@
 
 ## Remaining Gap Register
 
+## In-flight claim — ISSUE-214 resource-pool clear linearizability [patch]
+
+- [x] Claim `moirai-sync/src/sync/resource_pool.rs`, its co-located tests and
+      benchmarks, and this provider PM scope on
+      `codex/moirai-resource-clear-linearizable`.
+- [ ] Move recycle reservation behind the target-bin lock and retain all bin
+      guards while `clear` drains resources and publishes zero counters.
+- [ ] Add a deterministic barrier regression for reservation/insertion versus
+      clear and a value-semantic counter/retrieval check.
+- [ ] Run focused nextest, warning-denied Clippy, rustdoc, and a steady-state
+      Criterion comparison before updating the residual-risk record.
+
+Acceptance: `clear` has a linearizable boundary with `recycle` and `take`,
+steady-state operations acquire no new shard-wide lock, and no resource can
+remain hidden behind stale counters.
+
 - [x] [patch] ISSUE-210: Remove leaked source-vector allocations from indexed
   collect-into-existing-storage and interleave operations. Owned iteration now
   moves non-`Clone` elements into retained/exact-capacity outputs and releases

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -18,12 +18,14 @@
 - [x] Claim `moirai-sync/src/sync/resource_pool.rs`, its co-located tests and
       benchmarks, and this provider PM scope on
       `codex/moirai-resource-clear-linearizable`.
-- [ ] Move recycle reservation behind the target-bin lock and retain all bin
+- [x] Move recycle reservation behind the target-bin lock and retain all bin
       guards while `clear` drains resources and publishes zero counters.
-- [ ] Add a deterministic barrier regression for reservation/insertion versus
+- [x] Add a deterministic barrier regression for reservation/insertion versus
       clear and a value-semantic counter/retrieval check.
-- [ ] Run focused nextest, warning-denied Clippy, rustdoc, and a steady-state
-      Criterion comparison before updating the residual-risk record.
+- [x] Run focused nextest, warning-denied Clippy, rustdoc, doctests, and a
+      steady-state Criterion baseline. `resource_pool/recycle_take` median is
+      28.088 ns with a 27.984–28.190 ns confidence interval; no speedup claim
+      is made without a same-machine pre-change comparator.
 
 Acceptance: `clear` has a linearizable boundary with `recycle` and `take`,
 steady-state operations acquire no new shard-wide lock, and no resource can
@@ -61,7 +63,7 @@ remain hidden behind stale counters.
 - [ ] [arch] ISSUE-213: Isolate `BlockingTask` execution from unified compute
   workers so blocking work cannot occupy the complete scheduler. Preserve one
   Moirai-owned runtime; Tokio and Smol remain comparison references only.
-- [ ] [patch] ISSUE-214: Serialize `ShardedResourcePool::clear` against
+- [x] [patch] ISSUE-214: Serialize `ShardedResourcePool::clear` against
   recycle/take mutations without adding a single contended hot-path lock.
 - [x] [patch] ISSUE-217: Remove the executor's hidden index-count grain floor so
   explicit `Parallel` policy owns forced scheduling; flatten worker-nested

--- a/docs/concurrency_audit.md
+++ b/docs/concurrency_audit.md
@@ -40,11 +40,11 @@ the unified compute worker pool. A full worker count of blocking tasks can starv
 all scheduler progress. The accepted direction is a bounded Moirai-owned
 blocking lane; Tokio and Smol remain comparison references, not dependencies.
 
-**Filed (resource accounting, ISSUE-214).** `ShardedResourcePool::clear` can
-reset counters between recycle's reservation and bin insertion, leaving stored
-items hidden behind zero counters or enabling a later decrement underflow. The
-fix requires a linearizable clear/mutation ownership protocol; stronger atomic
-orderings alone are insufficient.
+**Closed in Round 25 (resource accounting, ISSUE-214).** The prior
+`ShardedResourcePool::clear` race reset counters between recycle's reservation
+and bin insertion, leaving stored items hidden behind zero counters or enabling
+a later decrement underflow. Round 25 supplies the linearizable ownership
+protocol; stronger atomic orderings alone were insufficient.
 
 **Runtime dependency verdict.** Rayon and Tokio remain dev-only differential
 and performance references. Crossbeam remains a queue/deque oracle unless a
@@ -59,6 +59,28 @@ out-of-bounds resource-pool path in the current design: recycle rejects any item
 larger than `max_bytes / 4`, and take checks a shard's retained-byte count before
 indexing the requested bin. A shard cannot retain enough bytes to enter that
 branch for bin 64. No bin-count change is justified.
+
+## Round 25 (2026-07-15) — FIXED: resource-pool clear linearizability
+
+**Root cause.** `ShardedResourcePool::recycle` reserved retained counters before
+publishing into its bin, while `clear` drained bins and reset the counters as
+separate operations. A clear could therefore publish zero counters while a
+reserved item was still in flight, hiding the item or causing a later counter
+decrement to underflow.
+
+**Fix.** Recycle now holds the existing target-bin guard from reservation through
+publication. Clear acquires every bin guard in deterministic order before
+draining and resetting the shard counters, then drops guards before dropping
+resources so destructors cannot re-enter a held lock. No shard-wide lock was
+added to steady-state take/recycle operations.
+
+**Evidence.** The pool-local deterministic interleaving regression pauses recycle
+after reservation, waits for clear to reach the exact target bin, then verifies
+clear completion and exact retrieval/counter behavior. Focused nextest passes;
+package nextest passes 20/20, warning-denied all-target Clippy and rustdoc are
+clean, doctests run 0/0, and the new Criterion baseline measures a 28.088 ns
+median with a 27.984–28.190 ns confidence interval. No speedup claim is made
+without a same-machine pre-change comparator.
 
 ## Round 23 (2026-07-03) — FIXED: `join()` quiescence lost-wakeup (Dekker, AcqRel→SeqCst)
 

--- a/docs/concurrency_audit.md
+++ b/docs/concurrency_audit.md
@@ -80,7 +80,9 @@ clear completion and exact retrieval/counter behavior. Focused nextest passes;
 package nextest passes 20/20, warning-denied all-target Clippy and rustdoc are
 clean, doctests run 0/0, and the new Criterion baseline measures a 28.088 ns
 median with a 27.984–28.190 ns confidence interval. No speedup claim is made
-without a same-machine pre-change comparator.
+without a same-machine pre-change comparator. Provider PR #70 is ready for
+review; GitHub currently reports `recurseml/analysis` errored and CodeRabbit
+pending, so integration remains open.
 
 ## Round 23 (2026-07-03) — FIXED: `join()` quiescence lost-wakeup (Dekker, AcqRel→SeqCst)
 

--- a/moirai-sync/Cargo.toml
+++ b/moirai-sync/Cargo.toml
@@ -23,6 +23,10 @@ libc = "0.2"
 criterion = { workspace = true }
 proptest = { workspace = true }
 
+[[bench]]
+name = "resource_pool"
+harness = false
+
 [features]
 default = []
 metrics = ["moirai-core/metrics"]

--- a/moirai-sync/benches/resource_pool.rs
+++ b/moirai-sync/benches/resource_pool.rs
@@ -1,0 +1,29 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use moirai_sync::{ShardedResourcePool, SizeBounded};
+
+struct Resource {
+    size: u64,
+}
+
+impl SizeBounded for Resource {
+    fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+fn recycle_take(c: &mut Criterion) {
+    let pool = ShardedResourcePool::new(1024, 1 << 20);
+
+    c.bench_function("resource_pool/recycle_take", |b| {
+        b.iter(|| {
+            pool.recycle(Resource { size: 64 });
+            black_box(
+                pool.take_at_least(64)
+                    .expect("recycled resource must be available"),
+            );
+        });
+    });
+}
+
+criterion_group!(benches, recycle_take);
+criterion_main!(benches);

--- a/moirai-sync/src/sync/resource_pool.rs
+++ b/moirai-sync/src/sync/resource_pool.rs
@@ -57,6 +57,8 @@ pub struct ShardedResourcePool<T> {
     shards: [Shard<T>; 4],
     shard_max_buffers: usize,
     shard_max_bytes: u64,
+    #[cfg(test)]
+    test_hook: test_support::Hook,
 }
 
 impl<T> std::fmt::Debug for ShardedResourcePool<T> {
@@ -76,6 +78,8 @@ impl<T: SizeBounded> ShardedResourcePool<T> {
             shards: [Shard::new(), Shard::new(), Shard::new(), Shard::new()],
             shard_max_buffers: (max_buffers / 4).max(1),
             shard_max_bytes: max_bytes / 4,
+            #[cfg(test)]
+            test_hook: test_support::Hook::new(),
         }
     }
 
@@ -192,6 +196,11 @@ impl<T: SizeBounded> ShardedResourcePool<T> {
         let local_shard = &self.shards[local_idx];
         let bin_idx = bin_index(size);
 
+        // The target-bin guard covers reservation through publication. `clear`
+        // acquires every bin guard before draining or resetting counters, so it
+        // cannot publish a zero-counter state between these two mutations.
+        let mut target_guard = local_shard.bins[bin_idx].lock();
+
         // Reserve this item's count and bytes up front, before inserting, so the
         // eviction decision below sees a total that already includes this item
         // *and* every other concurrent recycler's in-flight contribution. The
@@ -213,7 +222,22 @@ impl<T: SizeBounded> ShardedResourcePool<T> {
         while current_count > self.shard_max_buffers || current_bytes > self.shard_max_bytes {
             let mut progress = false;
             for b in 0..64 {
-                if let Some(mut guard) = local_shard.bins[b].try_lock() {
+                if b == bin_idx {
+                    if let Some(removed) = target_guard.pop_front() {
+                        let removed_size = removed.size();
+                        // Decrements remove already-inserted items, never our
+                        // reservation, so the net total keeps counting our item.
+                        local_shard.retained_count.fetch_sub(1, Ordering::Release);
+                        local_shard
+                            .retained_bytes
+                            .fetch_sub(removed_size, Ordering::Release);
+                        current_count -= 1;
+                        current_bytes = current_bytes.saturating_sub(removed_size);
+                        evicted.push(removed);
+                        progress = true;
+                        break;
+                    }
+                } else if let Some(mut guard) = local_shard.bins[b].try_lock() {
                     if let Some(removed) = guard.pop_front() {
                         let removed_size = removed.size();
                         // Decrements remove already-inserted items, never our
@@ -235,24 +259,163 @@ impl<T: SizeBounded> ShardedResourcePool<T> {
             }
         }
 
-        drop(evicted);
+        #[cfg(test)]
+        self.test_hook.pause_after_reservation(local_idx, bin_idx);
 
         // The counters already account for this item (reserved above); inserting
         // it makes the bin contents consistent with the published totals.
-        local_shard.bins[bin_idx].lock().push_back(item);
+        target_guard.push_back(item);
+        drop(target_guard);
+        drop(evicted);
     }
 
     /// Clear all pooled resources.
+    ///
+    /// All bin guards remain held until the bins are drained and the counters
+    /// are reset. This makes the reset a linearization point: a concurrent
+    /// `recycle` or `take_at_least` either completes before the reset or starts
+    /// after it, and cannot publish a resource behind zero counters.
     pub fn clear(&self) {
-        for shard in &self.shards {
+        for (shard_idx, shard) in self.shards.iter().enumerate() {
+            #[cfg(not(test))]
+            let _ = shard_idx;
+            let mut guards: [Option<_>; 64] = std::array::from_fn(|_| None);
+            for (bin_idx, bin) in shard.bins.iter().enumerate() {
+                #[cfg(test)]
+                self.test_hook.announce_clear(shard_idx, bin_idx);
+                guards[bin_idx] = Some(bin.lock());
+            }
+
             let mut evicted = Vec::new();
-            for b in 0..64 {
-                let mut guard = shard.bins[b].lock();
+            for guard in guards.iter_mut().flatten() {
                 evicted.extend(guard.drain(..));
             }
             shard.retained_bytes.store(0, Ordering::Release);
             shard.retained_count.store(0, Ordering::Release);
+
+            drop(guards);
             drop(evicted);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_test_hook(
+        &self,
+        recycle_entered: std::sync::mpsc::SyncSender<()>,
+        clear_started: std::sync::mpsc::SyncSender<()>,
+        release: std::sync::Arc<std::sync::Barrier>,
+    ) -> test_support::HookGuard {
+        self.test_hook
+            .install(recycle_entered, clear_started, release)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{mpsc::SyncSender, Arc, Barrier, Mutex};
+
+    struct InterleavingHook {
+        recycle_entered: SyncSender<()>,
+        clear_started: SyncSender<()>,
+        release: Arc<Barrier>,
+        target: Option<(usize, usize)>,
+        clear_announced: bool,
+    }
+
+    pub(crate) struct Hook {
+        state: Arc<Mutex<Option<InterleavingHook>>>,
+    }
+
+    impl Hook {
+        pub(crate) fn new() -> Self {
+            Self {
+                state: Arc::new(Mutex::new(None)),
+            }
+        }
+
+        pub(crate) fn install(
+            &self,
+            recycle_entered: SyncSender<()>,
+            clear_started: SyncSender<()>,
+            release: Arc<Barrier>,
+        ) -> HookGuard {
+            let mut hook = self
+                .state
+                .lock()
+                .expect("invariant: test hook mutex poisoned");
+            assert!(
+                hook.is_none(),
+                "invariant: only one interleaving hook is active"
+            );
+            *hook = Some(InterleavingHook {
+                recycle_entered,
+                clear_started,
+                release,
+                target: None,
+                clear_announced: false,
+            });
+            HookGuard {
+                state: Arc::clone(&self.state),
+            }
+        }
+
+        pub(crate) fn pause_after_reservation(&self, shard_idx: usize, bin_idx: usize) {
+            let (entered, release) = {
+                let mut hook = self
+                    .state
+                    .lock()
+                    .expect("invariant: test hook mutex poisoned");
+                let Some(hook) = hook.as_mut() else {
+                    return;
+                };
+                assert!(
+                    hook.target.replace((shard_idx, bin_idx)).is_none(),
+                    "invariant: only one recycle interleaving is active"
+                );
+                (hook.recycle_entered.clone(), Arc::clone(&hook.release))
+            };
+
+            entered
+                .send(())
+                .expect("invariant: interleaving test receiver remains active");
+            release.wait();
+        }
+
+        pub(crate) fn announce_clear(&self, shard_idx: usize, bin_idx: usize) {
+            let started = {
+                let mut hook = self
+                    .state
+                    .lock()
+                    .expect("invariant: test hook mutex poisoned");
+                let Some(hook) = hook.as_mut() else {
+                    return;
+                };
+                if hook.target == Some((shard_idx, bin_idx)) && !hook.clear_announced {
+                    hook.clear_announced = true;
+                    Some(hook.clear_started.clone())
+                } else {
+                    None
+                }
+            };
+
+            if let Some(started) = started {
+                started
+                    .send(())
+                    .expect("invariant: interleaving test receiver remains active");
+            }
+        }
+    }
+
+    pub(crate) struct HookGuard {
+        state: Arc<Mutex<Option<InterleavingHook>>>,
+    }
+
+    impl Drop for HookGuard {
+        fn drop(&mut self) {
+            self.state
+                .lock()
+                .expect("invariant: test hook mutex poisoned")
+                .take();
         }
     }
 }

--- a/moirai-sync/src/sync/tests.rs
+++ b/moirai-sync/src/sync/tests.rs
@@ -489,3 +489,55 @@ fn test_sharded_resource_pool_concurrent_recycle_respects_total_cap() {
         "retained {retained} exceeds the aggregate cap of {MAX_BUFFERS}"
     );
 }
+
+#[test]
+fn test_sharded_resource_pool_clear_serializes_reservation_and_insertion() {
+    use std::sync::{mpsc::sync_channel, Barrier};
+
+    let (recycle_entered_tx, recycle_entered_rx) = sync_channel(0);
+    let (clear_started_tx, clear_started_rx) = sync_channel(0);
+    let (clear_done_tx, clear_done_rx) = sync_channel(0);
+    let release = Arc::new(Barrier::new(2));
+    let pool = Arc::new(ShardedResourcePool::<TestResource>::new(16, 1024));
+    let _hook = pool.install_test_hook(recycle_entered_tx, clear_started_tx, Arc::clone(&release));
+
+    let recycle_pool = Arc::clone(&pool);
+    let recycler = thread::spawn(move || {
+        recycle_pool.recycle(TestResource { id: 7, size: 100 });
+    });
+    recycle_entered_rx
+        .recv()
+        .expect("recycle must reach the reservation/insertion boundary");
+
+    let clear_pool = Arc::clone(&pool);
+    let clearer = thread::spawn(move || {
+        clear_pool.clear();
+        clear_done_tx
+            .send(())
+            .expect("clear completion receiver remains active");
+    });
+    clear_started_rx
+        .recv()
+        .expect("clear must enter before waiting on the target bin");
+    assert!(
+        clear_done_rx.try_recv().is_err(),
+        "clear must not complete while recycle owns the target bin"
+    );
+
+    release.wait();
+    recycler.join().expect("recycle worker must not panic");
+    clear_done_rx
+        .recv()
+        .expect("clear must complete after recycle publishes its item");
+    clearer.join().expect("clear worker must not panic");
+
+    assert!(
+        pool.take_at_least(100).is_none(),
+        "clear must remove the item published at the interleaving boundary"
+    );
+
+    drop(_hook);
+    pool.recycle(TestResource { id: 8, size: 100 });
+    assert_eq!(pool.take_at_least(100).map(|resource| resource.id), Some(8));
+    assert!(pool.take_at_least(100).is_none());
+}


### PR DESCRIPTION
## Summary

- Make `ShardedResourcePool::clear` linearizable with recycle reservation and publication.
- Retain the existing target-bin guard through reservation, eviction, and publication.
- Drain all bins under deterministic guard ownership, reset counters, then drop resources after releasing locks.
- Add a pool-local deterministic interleaving regression and a `recycle_take` Criterion baseline.

## Root cause

`recycle` reserved retained counters before bin insertion while `clear` drained bins and reset counters independently. A clear between those operations could hide a resource behind zero counters or permit a later counter underflow.

## Validation

- `rustup run nightly cargo nextest run -p moirai-sync --locked --no-fail-fast` — 20/20
- `rustup run nightly cargo clippy -p moirai-sync --all-targets --locked -- -D warnings`
- `rustup run nightly cargo doc -p moirai-sync --no-deps --locked`
- `rustup run nightly cargo test --doc -p moirai-sync --locked` — 0/0
- `rustup run nightly cargo bench -p moirai-sync --bench resource_pool --locked -- --quiet` — median 28.088 ns, CI 27.984–28.190 ns

No speedup claim is made without a same-machine pre-change comparator.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a race condition in `ShardedResourcePool::clear` where counters could be reset between a `recycle` operation's counter reservation and bin insertion, potentially hiding resources behind zero counters or causing underflows. The fix makes `clear` linearizable by holding the target bin guard from reservation through publication in `recycle`, and acquiring all bin guards in `clear` before draining resources and resetting counters. The changes include a deterministic interleaving regression test to validate the fix and a new Criterion benchmark baseline for `recycle_take` operations.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-sync/src/sync/resource_pool.rs` |
| 2 | `moirai-sync/src/sync/tests.rs` |
| 3 | `moirai-sync/benches/resource_pool.rs` |
| 4 | `moirai-sync/Cargo.toml` |
| 5 | `CHANGELOG.md` |
| 6 | `docs/concurrency_audit.md` |
| 7 | `docs/backlog.md` |
| 8 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->