### PR TITLE
build(deps): Pin Atlas provider sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Remove the Themis and Mnemosyne revision quarantines. The provider graph now
-  follows the default branches and resolves one Themis source identity through
-  both direct and transitive dependencies.
+- Pin Themis and Mnemosyne to audited revisions that resolve one provider source
+  identity through both direct and transitive dependencies.
 
 ## [0.3.0] - 2026-07-15
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,9 +1,9 @@
 # Moirai Development Checklist
 
-- [ ] [patch] Publish 0.3.1 with the default-branch Themis and Mnemosyne
-  provider contract; delete the root-only Themis path patch and refresh the
-  lockfile. Evidence target: one Themis source identity plus focused provider
-  nextest and warning-denied Clippy.
+- [x] [patch] Pin the audited Themis and Mnemosyne provider revisions in the
+  workspace dependency SSOT and refresh the lockfile. Evidence: one Themis
+  and one Mnemosyne source identity; warning-denied `moirai-gpu` Clippy; and
+  `cargo nextest run -p moirai-gpu --all-features --locked` passes 10/10.
 - [x] [patch] Publish the Themis 0.10.0/Mnemosyne 0.4.0 topology graph and
   verify the `moirai-gpu` provider consumer without a local source override.
   Evidence: warning-denied Clippy; 33/33 focused nextest; the GPU dependency

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne"
 version = "0.4.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1111,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-arena"
 version = "0.2.1"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
  "mnemosyne-backend",
  "mnemosyne-core",
@@ -1121,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-backend"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
  "mnemosyne-core",
 ]
@@ -1129,17 +1129,17 @@ dependencies = [
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 
 [[package]]
 name = "mnemosyne-core"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-hardened"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
  "mnemosyne-core",
 ]
@@ -1157,7 +1157,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-local"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "mnemosyne-prof"
 version = "0.1.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#9b8585db0562c6436565ca6175abe79a040f399b"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git?rev=32b4a2ac71f909205b58d68c3b244caf99407b2d#32b4a2ac71f909205b58d68c3b244caf99407b2d"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "themis"
 version = "0.10.0"
-source = "git+https://github.com/ryancinsight/themis#18807bb5c43f4dc4cb6cedefeee2cc12375056c1"
+source = "git+https://github.com/ryancinsight/themis?rev=18807bb5c43f4dc4cb6cedefeee2cc12375056c1#18807bb5c43f4dc4cb6cedefeee2cc12375056c1"
 dependencies = [
  "melinoe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,10 @@ moirai-metrics = { path = "moirai-metrics", version = "0.3.1" }
 moirai-utils = { path = "moirai-utils", version = "0.3.1", features = ["std"] }
 moirai-gpu = { path = "moirai-gpu", version = "0.3.1" }
 melinoe = { git = "https://github.com/ryancinsight/melinoe.git", rev = "bb07447f6c71978c6fed47114ba9ecfda965ddc9", version = "0.9.0", default-features = false }
-themis = { git = "https://github.com/ryancinsight/themis", version = "0.10", default-features = false, features = ["std"] }
+themis = { git = "https://github.com/ryancinsight/themis", rev = "18807bb5c43f4dc4cb6cedefeee2cc12375056c1", version = "0.10", default-features = false, features = ["std"] }
 # Kernel resource budget vocabulary for the GPU occupancy planner (atlas ADR 0002).
-mnemosyne-core = { git = "https://github.com/ryancinsight/Mnemosyne.git", version = "0.1.0", package = "mnemosyne-core", default-features = false }
-mnemosyne = { git = "https://github.com/ryancinsight/Mnemosyne.git", version = "0.4.0", default-features = false }
+mnemosyne-core = { git = "https://github.com/ryancinsight/Mnemosyne.git", rev = "32b4a2ac71f909205b58d68c3b244caf99407b2d", version = "0.1.0", package = "mnemosyne-core", default-features = false }
+mnemosyne = { git = "https://github.com/ryancinsight/Mnemosyne.git", rev = "32b4a2ac71f909205b58d68c3b244caf99407b2d", version = "0.4.0", default-features = false }
 
 # Network stack (ADR-015): sans-I/O, runtime-agnostic, NOT tokio-coupled.
 # `ring` crypto provider (no aws-lc-rs NASM/cmake toolchain requirement on Windows).


### PR DESCRIPTION
Pins Themis and Mnemosyne to the audited Atlas provider revisions and refreshes Cargo.lock so each provider has one source identity. Verified focused build, warning-denied Clippy, 10/10 nextest, doctests, and rustdoc.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR pins the Themis and Mnemosyne Atlas provider dependencies to specific audited Git revisions instead of following default branches. This ensures reproducible builds by resolving each provider to a single source identity across both direct and transitive dependencies. The `Cargo.lock` file is refreshed to reflect these pinned revisions, and the CHANGELOG and checklist are updated to document the change.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
| 3 | `CHANGELOG.md` |
| 4 | `CHECKLIST.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->