### PR TITLE
fix(moirai): Restore lint and backlog records

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -222,6 +222,28 @@ architecture definition.
 - **Evidence tier**: deductive interleaving proof plus value-semantic nextest,
   warning-denied Clippy, rustdoc, doctest, Criterion, and GitHub review
   evidence.
+#### ✅ ISSUE-217 [patch]: Honor forced indexed parallelism under nesting
+- **Type**: Scheduler correctness / consumer performance
+- **Root Cause**: the scheduler applied an undocumented 256-index grain floor
+  after `moirai-parallel` had already selected an execution policy, silently
+  serializing explicit `Parallel` domains such as RITK's 9–18 expensive CMA
+  candidates. Once those candidates run concurrently, recursively stealing
+  unrelated outer jobs from nested histogram waits grows worker stacks and can
+  exhaust them; parking the nested waits instead deadlocks a saturated pool.
+- **Acceptance criteria**: explicit `Parallel` schedules a two-item domain
+  across caller and worker lanes; both indexed operation families flatten when
+  entered from a worker; a barrier-synchronized two-worker nested fan-out
+  completes and returns the closed-form arithmetic-series sum; a domain just
+  above the lane cap executes one physical chunk per selected lane.
+- **Status**: resolved. RITK's CMA population evaluation supplied the consumer
+  reproduction: outer candidate evaluation nests masked-histogram reductions.
+- **Evidence tier**: type-level policy selection, structural deadlock argument,
+  and value-semantic policy plus saturation regressions under nextest.
+- **Verification**: current-main `moirai-executor` plus `moirai-parallel`
+  109/109 in 1.118 s; the consumer-compatible 0.2 line passes executor 77/77
+  and parallel 29/29. Indexed scheduler source contract, focused
+  all-target/all-feature clippy, and rustdoc are warning-clean.
+
 #### ✅ ISSUE-218 [major]: Dual channel consolidation (TREE-DUP-002)
 - **Type**: Module Hierarchy / API Contract
 - **Root Cause**: `moirai-core` had two parallel channel systems at `channel/`

--- a/moirai-iter/src/advanced_patterns.rs
+++ b/moirai-iter/src/advanced_patterns.rs
@@ -104,8 +104,7 @@ impl<T> ProducerConsumerPair<T> {
             ..Default::default()
         };
 
-        let (sender, receiver) =
-            moirai_core::channel::unified_channel_with_config(config.clone())?;
+        let (sender, receiver) = moirai_core::channel::unified_channel_with_config(config.clone())?;
 
         Ok(Self {
             sender,

--- a/moirai-iter/src/iter_ops/stateful.rs
+++ b/moirai-iter/src/iter_ops/stateful.rs
@@ -101,7 +101,10 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        #[allow(clippy::manual_inspect)]
+        #[expect(
+            clippy::manual_inspect,
+            reason = "UpdateInPlace must return the consumed mutable reference after mutation"
+        )]
         self.iter.next().map(|item| {
             (self.updater)(item);
             item


### PR DESCRIPTION
Restores the completed ISSUE-217 backlog record, replaces the stale manual-inspect allowance with a self-expiring expectation, and normalizes the channel consumer formatting.\n\nVerification: nightly fmt check; warning-denied Clippy for moirai-core and moirai-iter; focused nextest; moirai-core docs.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR restores the completed ISSUE-217 backlog record that documents a scheduler correctness fix for nested parallelism, replaces a stale `allow` attribute with a self-expiring `expect` attribute that includes a justification for the `clippy::manual_inspect` lint, and normalizes formatting for a channel consumer initialization by removing extraneous line breaks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-iter/src/iter_ops/stateful.rs` |
| 2 | `moirai-iter/src/advanced_patterns.rs` |
| 3 | `docs/backlog.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->