### PR TITLE
fix(executor): Guard scoped state lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep stack-owned scheduler scope state alive until the final completion
+  releases its wait synchronization, preventing a multi-job scoped fan-out from
+  hanging or dereferencing destroyed state.
+
 ## [0.4.0] - 2026-07-17
 
 ### Changed

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,6 +2,15 @@
 
 **Target Version**: 0.4.0
 
+## MOI-SCOPE-059 — scoped multi-job memory safety [patch] — in-progress
+
+- Owner: Codex Tyche integration.
+- Scope: `moirai-executor/src/schedule/{job,runtime/scheduler}` and focused
+  scoped-dispatch regression coverage.
+- Reproduce Tyche's multi-job borrowed-slice access violation without Tyche,
+  repair the owning scheduler invariant, and verify value semantics plus Miri
+  or sanitizer coverage where supported.
+
 ## Moirai 0.4.0 release artifact closure [patch]
 
 - [x] Take over the stale release-artifact increment after one hour without

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,14 +2,24 @@
 
 **Target Version**: 0.4.0
 
-## MOI-SCOPE-059 — scoped multi-job memory safety [patch] — in-progress
+## MOI-SCOPE-059 — scoped multi-job memory safety [patch] — ready-review
 
 - Owner: Codex Tyche integration.
 - Scope: `moirai-executor/src/schedule/{job,runtime/scheduler}` and focused
   scoped-dispatch regression coverage.
-- Reproduce Tyche's multi-job borrowed-slice access violation without Tyche,
-  repair the owning scheduler invariant, and verify value semantics plus Miri
-  or sanitizer coverage where supported.
+- [x] Reproduce Tyche's multi-job borrowed-slice access violation without
+      Tyche.
+- [x] Publish the final zero count while holding the wait lock, and require
+      both caller and worker waiters to acquire that lock before destroying the
+      stack-owned scope state.
+- [x] Verify the 64-round borrowed-chunk regression, the bounded one-completion
+      Loom model, and the complete executor package.
+- Evidence: configured Nextest passes `moirai-executor` 89/89 with one
+  cfg-gated skip; warning-denied all-target/all-feature Clippy, rustfmt,
+  doctests, and rustdoc pass. The bounded Loom model passes 1/1. Miri cannot
+  reach the regression on Windows because Themis NUMA detection calls the
+  unsupported `GetNumaHighestNodeNumber` FFI; it reports no result for this
+  invariant.
 
 ## Moirai 0.4.0 release artifact closure [patch]
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,7 +2,7 @@
 
 **Target Version**: 0.4.0
 
-## MOI-SCOPE-059 — scoped multi-job memory safety [patch] — ready-review
+## MOI-SCOPE-059 — scoped multi-job memory safety [patch] — done
 
 - Owner: Codex Tyche integration.
 - Scope: `moirai-executor/src/schedule/{job,runtime/scheduler}` and focused
@@ -19,7 +19,8 @@
   doctests, and rustdoc pass. The bounded Loom model passes 1/1. Miri cannot
   reach the regression on Windows because Themis NUMA detection calls the
   unsupported `GetNumaHighestNodeNumber` FFI; it reports no result for this
-  invariant.
+  invariant. PR 81 contains the delivery; Moirai has no repository engineering
+  workflow beyond the non-gating Copilot workflow.
 
 ## Moirai 0.4.0 release artifact closure [patch]
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,7 +14,7 @@
       stack-owned scope state.
 - [x] Verify the 64-round borrowed-chunk regression, the bounded one-completion
       Loom model, and the complete executor package.
-- Evidence: configured Nextest passes `moirai-executor` 89/89 with one
+- Evidence: configured Nextest passes `moirai-executor` 88/88 with one
   cfg-gated skip; warning-denied all-target/all-feature Clippy, rustfmt,
   doctests, and rustdoc pass. The bounded Loom model passes 1/1. Miri cannot
   reach the regression on Windows because Themis NUMA detection calls the

--- a/moirai-executor/src/hybrid/tests.rs
+++ b/moirai-executor/src/hybrid/tests.rs
@@ -2,6 +2,7 @@
 #[allow(clippy::module_inception)]
 mod tests {
     use super::super::HybridExecutor;
+    use crate::SyncTask;
     use moirai_core::{
         executor::{ExecutorConfig, ExecutorControl, TaskManager, TaskSpawner, TaskStatus},
         task::TaskBuilder,
@@ -23,6 +24,41 @@ mod tests {
         assert_eq!(result, 42);
         assert_eq!(executor.task_status(id), Some(TaskStatus::Completed));
         executor.shutdown();
+    }
+
+    #[test]
+    fn scoped_chunks_complete_before_inherent_shutdown() {
+        const LEN: usize = 257;
+        const CHUNK: usize = 7;
+        const ROUNDS: usize = 64;
+
+        let mut executor = HybridExecutor::new(ExecutorConfig {
+            worker_threads: 2,
+            ..ExecutorConfig::default()
+        })
+        .unwrap();
+
+        for round in 0..ROUNDS {
+            let mut values = vec![usize::MAX; LEN];
+            executor
+                .scope::<SyncTask, _>(|scope| {
+                    for (chunk_index, chunk) in values.chunks_mut(CHUNK).enumerate() {
+                        let first = chunk_index * CHUNK;
+                        scope.spawn(move |_| {
+                            for (offset, value) in chunk.iter_mut().enumerate() {
+                                *value = first + offset;
+                            }
+                        })?;
+                    }
+                    Ok(())
+                })
+                .unwrap();
+
+            for (index, value) in values.into_iter().enumerate() {
+                assert_eq!(value, index, "round {round} lost logical slot {index}");
+            }
+        }
+        HybridExecutor::shutdown(&mut executor).unwrap();
     }
 
     #[test]

--- a/moirai-executor/src/schedule/runtime/scheduler/core.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/core.rs
@@ -225,6 +225,7 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
         let mut idle_spins = 0usize;
         loop {
             if state.pending_tasks.load(Ordering::Acquire) == 0 {
+                state.wait();
                 return;
             }
 

--- a/moirai-executor/src/schedule/runtime/types.rs
+++ b/moirai-executor/src/schedule/runtime/types.rs
@@ -346,9 +346,35 @@ impl SchedulerScopeState {
     }
 
     pub(super) fn complete_task(&self) {
-        if self.pending_tasks.fetch_sub(1, Ordering::AcqRel) == 1 {
-            let _guard = super::worker::lock_mutex(&self.wait_lock);
-            self.wait_signal.notify_all();
+        loop {
+            let pending = self.pending_tasks.load(Ordering::Acquire);
+            debug_assert!(pending > 0, "scoped completion count must not underflow");
+
+            if pending == 1 {
+                // Hold the wait lock before publishing zero. Every waiter
+                // acquires this lock after observing zero, so the stack-owned
+                // scope state cannot be destroyed until this completion token
+                // has finished its last access to the mutex and condition
+                // variable.
+                let _guard = super::worker::lock_mutex(&self.wait_lock);
+                if self
+                    .pending_tasks
+                    .compare_exchange(1, 0, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    self.wait_signal.notify_all();
+                    return;
+                }
+                continue;
+            }
+
+            if self
+                .pending_tasks
+                .compare_exchange_weak(pending, pending - 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return;
+            }
         }
     }
 
@@ -356,11 +382,14 @@ impl SchedulerScopeState {
         // Spin-wait for a short duration before acquiring the lock and parking
         for _ in 0..131_072 {
             if self.pending_tasks.load(Ordering::Acquire) == 0 {
-                return;
+                break;
             }
             core::hint::spin_loop();
         }
 
+        // The final completion publishes zero while holding this lock. Taking
+        // it after the acquire load forms the lifetime handshake that proves
+        // the completion token no longer accesses this stack-owned state.
         let mut guard = super::worker::lock_mutex(&self.wait_lock);
         while self.pending_tasks.load(Ordering::Acquire) != 0 {
             guard = self

--- a/moirai-executor/tests/loom_scope_completion.rs
+++ b/moirai-executor/tests/loom_scope_completion.rs
@@ -1,0 +1,65 @@
+//! Bounded model of the scoped-completion lifetime handshake.
+//!
+//! A scheduler scope owns its completion counter, mutex, and condition
+//! variable on the caller's stack. The final completion must therefore hold
+//! the wait lock before publishing a zero count. A waiter that observes zero
+//! acquires the same lock before destroying the state, which proves that the
+//! completion thread has finished every access to that state.
+//!
+//! The model explores one final completion racing one waiter. This is the
+//! minimal state that exposed the lifetime violation; non-final decrements do
+//! not authorize destruction.
+
+#![cfg(loom)]
+
+use loom::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+use loom::thread;
+
+struct ScopeState {
+    pending: AtomicUsize,
+    wait_lock: Mutex<()>,
+    completion_released_state: AtomicBool,
+}
+
+#[test]
+fn zero_publication_happens_inside_wait_lock() {
+    loom::model(|| {
+        let state = Arc::new(ScopeState {
+            pending: AtomicUsize::new(1),
+            wait_lock: Mutex::new(()),
+            completion_released_state: AtomicBool::new(false),
+        });
+
+        let completion_state = Arc::clone(&state);
+        let completion = thread::spawn(move || {
+            let _guard = completion_state.wait_lock.lock().unwrap();
+            assert_eq!(
+                completion_state.pending.compare_exchange(
+                    1,
+                    0,
+                    Ordering::AcqRel,
+                    Ordering::Acquire
+                ),
+                Ok(1)
+            );
+            completion_state
+                .completion_released_state
+                .store(true, Ordering::Release);
+        });
+
+        while state.pending.load(Ordering::Acquire) != 0 {
+            thread::yield_now();
+        }
+        let _guard = state.wait_lock.lock().unwrap();
+        assert!(
+            state.completion_released_state.load(Ordering::Acquire),
+            "zero must not authorize destruction before completion releases state"
+        );
+        drop(_guard);
+
+        completion.join().unwrap();
+    });
+}


### PR DESCRIPTION
## Summary
- publish the final scoped completion count while holding the scope wait lock
- require caller and scheduler-worker waiters to acquire that lock after observing zero before stack-owned state can be destroyed
- add the exact 257-element, 7-wide borrowed-chunk regression over 64 rounds and a bounded Loom model of the final-completion race

## Root cause
`SchedulerScopeState::complete_task` previously changed `pending_tasks` from one to zero before locking and notifying. A waiter could observe zero, return, and destroy the stack-owned mutex/condition variable while the completion thread still dereferenced them. Tyche reproduced this as Windows access violation `0xc0000005`; the same public `HybridExecutor::scope` shape reproduced it directly in Moirai.

## Verification
- `cargo fmt -p moirai-executor -- --check`
- `cargo clippy -p moirai-executor --all-targets --all-features --locked -- -D warnings`
- `cargo nextest run -p moirai-executor --all-features --locked --no-fail-fast` (88 passed; 1 cfg-gated skip)
- `cargo test --doc -p moirai-executor --all-features --locked`
- `cargo doc -p moirai-executor --all-features --no-deps --locked`
- `RUSTFLAGS="--cfg loom" rustup run nightly cargo nextest run -p moirai-executor --test loom_scope_completion --locked --no-fail-fast` (1 passed)

## Coverage limit
Miri cannot reach the regression on Windows because Themis topology detection calls `GetNumaHighestNodeNumber`, which Miri does not support. It therefore supplies no evidence for this invariant; the executable stress regression and bounded Loom interleaving model are the applicable evidence.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical memory safety bug in the executor's scoped task completion mechanism. The issue occurred when the final task completion decremented the pending counter to zero before acquiring the wait lock, allowing waiters to observe zero, return, and destroy stack-owned synchronization primitives (mutex/condition variable) while the completion thread was still accessing them. The fix ensures that the final completion publishes zero *while holding* the wait lock, and requires all waiters to acquire that same lock after observing zero, creating a proper lifetime handshake that prevents use-after-free. The PR includes a 257-element regression test that reproduces the original Windows access violation and a Loom-based concurrency model that verifies the synchronization correctness.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-executor/tests/loom_scope_completion.rs` |
| 2 | `moirai-executor/src/schedule/runtime/types.rs` |
| 3 | `moirai-executor/src/schedule/runtime/scheduler/core.rs` |
| 4 | `moirai-executor/src/hybrid/tests.rs` |
| 5 | `CHECKLIST.md` |
| 6 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->