### PR TITLE
ci(release): Add crates.io OIDC publishing

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,108 @@
+name: Crates.io Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Workspace package to validate without publishing
+        required: true
+        type: string
+      version:
+        description: Exact Cargo package version
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crates-release-${{ github.event.release.tag_name || inputs.package }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, 'crate-')
+    name: Validate or publish crate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the release revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name || github.sha }}
+
+      - name: Resolve and validate release identity
+        id: release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PACKAGE: ${{ inputs.package }}
+          INPUT_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            if [[ "$RELEASE_TAG" =~ ^crate-(.+)-v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)$ ]]; then
+              package="${BASH_REMATCH[1]}"
+              version="${BASH_REMATCH[2]}"
+            else
+              echo "release tag must be crate-<package>-v<version>" >&2
+              exit 1
+            fi
+          else
+            package="$INPUT_PACKAGE"
+            version="$INPUT_VERSION"
+          fi
+
+          if [[ ! "$package" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
+            echo "invalid Cargo package name: $package" >&2
+            exit 1
+          fi
+
+          metadata="$(cargo metadata --locked --no-deps --format-version 1)"
+          matches="$(jq --arg package "$package" '[.packages[] | select(.name == $package)] | length' <<<"$metadata")"
+          if [[ "$matches" != "1" ]]; then
+            echo "expected exactly one workspace package named $package; found $matches" >&2
+            exit 1
+          fi
+
+          manifest_version="$(jq -r --arg package "$package" '.packages[] | select(.name == $package) | .version' <<<"$metadata")"
+          if [[ "$version" != "$manifest_version" ]]; then
+            echo "release version $version does not match Cargo version $manifest_version" >&2
+            exit 1
+          fi
+
+          publishable="$(jq -r --arg package "$package" '.packages[] | select(.name == $package) | (.publish == null or (.publish | index("crates-io") != null))' <<<"$metadata")"
+          if [[ "$publishable" != "true" ]]; then
+            echo "Cargo metadata marks $package as publish = false" >&2
+            exit 1
+          fi
+
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate package without publishing
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: cargo publish --locked --package "${{ steps.release.outputs.package }}" --dry-run
+
+      - name: Request a short-lived crates.io token
+        if: github.event_name == 'release'
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Package, verify, and publish
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked --package "${{ steps.release.outputs.package }}"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ wg.wait(); // Wait for all tasks
 - **No Workload Wrappers**: Benchmark-specific Python functions are excluded unless they correspond to a comparable joblib or Tokio runtime primitive.
 - **Release Distribution**: GitHub Releases tagged `moirai-python-v<version>` attach validated CPython 3.10–3.13 wheels for Linux, Windows, and macOS, then publish the same artifacts to PyPI through OIDC.
 
+### Rust Crate Releases
+
+The `Crates.io Release` workflow validates a named workspace package on manual
+dispatch. After that package's required first release is published locally and
+its crates.io Trusted Publisher is registered, a GitHub Release tagged
+`crate-<package>-v<version>` packages, verifies, and publishes the matching
+Cargo version with a short-lived OIDC token. The `moirai` registry name belongs
+to an unrelated project, so the local facade is explicitly non-publishable
+until a distinct public name is selected; the component crate names remain
+available.
+
 ```bash
 py -3.13 -m pip install moirai-python
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 rust-version = "1.95"
 authors = ["Moirai Contributors"]
 description = "Comprehensive performance benchmarks for Moirai concurrency library"
+publish = false
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/moirai-rs/moirai"
 

--- a/moirai-python/Cargo.toml
+++ b/moirai-python/Cargo.toml
@@ -10,6 +10,7 @@ documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 name = "_native"

--- a/moirai/Cargo.toml
+++ b/moirai/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
 description = "High-performance hybrid concurrency library for Rust - weaving the threads of fate"
+publish = false # The `moirai` crates.io name belongs to an unrelated project.
 
 [dependencies]
 moirai-core = { workspace = true }


### PR DESCRIPTION
## Change

- publish Rust packages from `crate-<package>-v<version>` GitHub Releases
- validate the tag against locked Cargo metadata before publication
- exchange GitHub OIDC for a short-lived crates.io token
- keep Python and tool-only packages outside the crates.io surface
- document the required first-release bootstrap

## Verification

- actionlint 1.7.12 on the workflow
- `cargo metadata --locked --no-deps`
- `git diff --check`
- package-readiness audit with `cargo package --no-verify --locked`

The official crates.io action is pinned to the v1.0.5 commit. No registry token
is stored in GitHub.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces automated Rust crate publishing to crates.io using GitHub's OIDC authentication. The new workflow validates package metadata against locked Cargo versions, extracts package and version information from GitHub Release tags following the `crate-<package>-v<version>` pattern, and publishes using short-lived tokens. The PR also marks several packages as non-publishable: `benchmarks` (a development tool), `moirai-python` (Python-only bindings), and the root `moirai` crate (name conflict with an existing crates.io package). Documentation has been added explaining the first-release bootstrap process and Trusted Publisher registration requirements.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
| 2 | `benchmarks/Cargo.toml` |
| 3 | `moirai-python/Cargo.toml` |
| 4 | `moirai/Cargo.toml` |
| 5 | `.github/workflows/rust-release.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->