### PR TITLE
fix(release): Harden crates.io publishing

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -21,23 +21,33 @@ concurrency:
   group: crates-release-${{ github.event.release.tag_name || inputs.package }}
   cancel-in-progress: false
 
+env:
+  RUST_TOOLCHAIN: 1.95.0
+
 jobs:
-  release:
+  validate:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'crate-')
-    name: Validate or publish crate
+    name: Validate crate package
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write
+    outputs:
+      package: ${{ steps.release.outputs.package }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Check out the release revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ github.event.release.tag_name || github.sha }}
+
+      - name: Install the pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Resolve and validate release identity
         id: release
@@ -90,19 +100,43 @@ jobs:
           echo "package=$package" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Validate package without publishing
-        if: github.event_name == 'workflow_dispatch'
+      - name: Package and verify without publishing
         shell: bash
-        run: cargo publish --locked --package "${{ steps.release.outputs.package }}" --dry-run
+        env:
+          RELEASE_PACKAGE: ${{ steps.release.outputs.package }}
+        run: cargo publish --locked --package "$RELEASE_PACKAGE" --dry-run
+
+  publish:
+    if: github.event_name == 'release'
+    needs: validate
+    name: Publish crate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: crates-io
+      url: https://crates.io/crates/${{ needs.validate.outputs.package }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the release revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install the pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Request a short-lived crates.io token
-        if: github.event_name == 'release'
         id: auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
-      - name: Package, verify, and publish
-        if: github.event_name == 'release'
+      - name: Publish the validated package
         shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --locked --package "${{ steps.release.outputs.package }}"
+          RELEASE_PACKAGE: ${{ needs.validate.outputs.package }}
+        run: cargo publish --locked --package "$RELEASE_PACKAGE" --no-verify

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ github.event.release.tag_name || github.sha }}
 
       - name: Install the pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Install the pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
@@ -139,4 +139,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           RELEASE_PACKAGE: ${{ needs.validate.outputs.package }}
-        run: cargo publish --locked --package "$RELEASE_PACKAGE" --no-verify
+        run: cargo publish --locked --package "$RELEASE_PACKAGE"

--- a/README.md
+++ b/README.md
@@ -138,10 +138,12 @@ The `Crates.io Release` workflow validates a named workspace package on manual
 dispatch. After that package's required first release is published locally and
 its crates.io Trusted Publisher is registered, a GitHub Release tagged
 `crate-<package>-v<version>` packages, verifies, and publishes the matching
-Cargo version with a short-lived OIDC token. The `moirai` registry name belongs
-to an unrelated project, so the local facade is explicitly non-publishable
-until a distinct public name is selected; the component crate names remain
-available.
+Cargo version with a short-lived OIDC token. Validation runs in a separate
+read-only job. The publish job is bound to the GitHub `crates-io` environment;
+register each package's Trusted Publisher with that environment. The `moirai`
+registry name belongs to an unrelated project, so the local facade is explicitly
+non-publishable until a distinct public name is selected; the component crate
+names remain available.
 
 ```bash
 py -3.13 -m pip install moirai-python


### PR DESCRIPTION
## Summary
- separate read-only package validation from OIDC publishing
- bind publishing to the crates-io GitHub environment
- install an explicit Rust toolchain and pass validated package names through environment variables

## Verification
- actionlint 1.7.12
- cargo metadata --locked --no-deps --format-version 1
- git diff --check

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the security of the crates.io publishing workflow by splitting validation and publishing into separate jobs, binding the publishing step to a dedicated `crates-io` GitHub environment for better access control, pinning the Rust toolchain version, and passing package names through environment variables to avoid injection vulnerabilities. The validation now runs in a read-only context, while only the publishing job requires OIDC credentials.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
| 2 | `.github/workflows/rust-release.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->