### PR TITLE
docs(parallel): Document ops.rs disjoint-mutation invariants

### DIFF
--- a/moirai-parallel/src/ops.rs
+++ b/moirai-parallel/src/ops.rs
@@ -1,3 +1,30 @@
+//! Synchronous data-parallel operators over the unified scheduler.
+//!
+//! # Safety
+//!
+//! The mutable operators split a buffer across worker tasks through
+//! `DisjointMutPtr`, which hands out `&mut` by raw pointer with no
+//! borrow-checker aliasing proof. Two executor contracts make
+//! every such access sound; each per-site `SAFETY` comment appeals to one of
+//! them:
+//!
+//! - **Disjoint partition.** `global().for_each_indexed(count, f)` invokes `f`
+//!   with each index in `0..count` exactly once. The operators map that index
+//!   (or a `chunk_size`-strided range derived from it) to a *disjoint* slice of
+//!   the buffer, so no two concurrent tasks ever form `&mut` to the same
+//!   element. Multi-buffer operators additionally rely on the caller's distinct
+//!   `&mut [_]` arguments being non-aliasing (guaranteed by the borrow checker
+//!   at the call site).
+//! - **All-or-error collect.** The `map_collect_*` helpers build a
+//!   `Vec<MaybeUninit<R>>`, `set_len` it (sound — `MaybeUninit` needs no
+//!   initialization), fill every slot through the disjoint-partition contract,
+//!   then reinterpret it as `Vec<R>`. `for_each_indexed` returns `Ok` only after
+//!   writing every index, so the reinterpretation is reached only when all slots
+//!   are initialized; a task panic instead surfaces as `Err`, which `.expect()`
+//!   turns into a propagating panic that unwinds with the buffer still typed
+//!   `MaybeUninit<R>` (its contents are not dropped — a leak of the written
+//!   values on panic, never a use of uninitialized memory).
+
 use super::DisjointMutPtr;
 use crate::policy::{ExecutionPolicy, Parallel};
 use moirai_core::error::ExecutorResult;


### PR DESCRIPTION
Second increment of the moirai unsafe audit — `moirai-parallel/src/ops.rs`, the synchronous data-parallel operators (join, scope, `for_each_mut`, chunk/pair/quad/triple mutation, `map_collect`/`map_reduce`/`fold_reduce`). 23 unsafe blocks.

## Audit result: clean

The mutable operators split a buffer across workers via `DisjointMutPtr` (raw-pointer `&mut`, no borrow-checker proof). I traced the disjointness math for every one:

- **Single-buffer** (`for_each_mut_with`, `for_each_chunk_mut_with`, …): each `for_each_indexed` index → a unique element / disjoint `[start, end)` chunk. Sound.
- **Multi-buffer** (`pair`/`quad`/`triple`): `quad`/`triple` assert equal lengths; `pair` documents and correctly handles `b.len() >= a.len()` (each slice individually bounded, guard skips chunks past either). Distinct `&mut` args are non-aliasing by the borrow checker. Sound.
- **`map_collect_*`**: the `Vec<MaybeUninit<R>>` + `set_len` + fill + reinterpret pattern — done **correctly** (unlike the bug this audit found in hermes's cow). I verified the one subtle point: soundness needs *all-or-nothing* fill. The data-parallel scheduler wraps tasks in `catch_unwind` (`execute_catching_panic`) and returns `Err` on a task panic, so `.expect()` propagates the panic **before** `from_raw_parts`, unwinding with the buffer still `MaybeUninit` (a leak of written values, never a read of uninitialized memory). The reinterpret is reached only on `Ok` = every slot written.

No defect found — a well-designed, panic-safe file at ~69% per-site coverage.

## The gap: the invariants were implicit

The per-site SAFETY comments each say "visited exactly once" but nothing stated the two executor contracts they rest on. This adds a module **`# Safety`** section naming them — **disjoint partition** and **all-or-error collect** — so the file's soundness is auditable from one place.

## Verification

Documentation only (diff is comments — no code lines changed). `moirai-parallel` fmt, `clippy -D warnings`, 30 nextest, 2 doctests, and the **warning-denied doc build** all pass. (The doc gate caught a `pub(crate)` intra-doc link locally before push — fixed to a plain code span.)

Next: the executor/async state machines (`moirai-executor/src/hybrid/async_state.rs`, `moirai-async/src/executor/result_slot.rs`) — where the cross-task state transitions live.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive module-level safety documentation to `ops.rs` in the `moirai-parallel` crate as part of an unsafe code audit. The new documentation explicitly describes two critical executor contracts—**disjoint partition** and **all-or-error collect**—that guarantee the soundness of data-parallel operators using raw pointer-based mutable slicing (`DisjointMutPtr`). The audit verified all 23 unsafe blocks in the file and found them sound, but the invariants were previously implicit in per-site comments. This change consolidates those invariants into a single Safety section for improved auditability. No code changes were made, only documentation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-parallel/src/ops.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->