### PR TITLE
docs(executor): Document async_state exclusivity invariant

### DIFF
--- a/moirai-executor/src/hybrid/async_state.rs
+++ b/moirai-executor/src/hybrid/async_state.rs
@@ -1,3 +1,40 @@
+//! Async future state machine.
+//!
+//! `AsyncFutureState` drives one `Future` to completion across the hybrid
+//! scheduler's worker threads. It is shared as an `Arc` (it is its own `Waker`),
+//! so a `Future` — which is `!Sync` to poll — is held in `UnsafeCell`s reachable
+//! from every clone. A single `AtomicU8` `state` makes the concurrent access to
+//! those cells sound.
+//!
+//! # State machine
+//!
+//! ```text
+//! IDLE ──schedule──▶ QUEUED ──poll claims──▶ POLLING ──Pending, no wake──▶ IDLE
+//!                                              │  │
+//!                          wake during poll ───┘  └── Ready / panic / cancel ─▶ COMPLETED
+//!                                (NOTIFIED, re-polled inline or rescheduled)
+//! ```
+//!
+//! # Exclusivity invariant
+//!
+//! The `QUEUED → POLLING` compare-exchange in `AsyncFutureState::poll` has
+//! exactly one winner; the loser returns without touching anything. That winner
+//! is the **poll owner**, and it is the *only* accessor of the `future`,
+//! `lifecycle`, `result_sender`, and `future_present` cells until it leaves
+//! `POLLING`. Wakers running on other threads only load/CAS `state` and never
+//! read those cells, so every `UnsafeCell` dereference here is single-threaded
+//! despite the shared `Arc` — this is what the per-site `Safety` comments mean by
+//! "the single poll owner selected by the async state machine". The `&mut` to the
+//! pinned future is dropped before any `state` transition, so no successor poll
+//! can observe it.
+//!
+//! A wake arriving mid-poll CASes `POLLING → NOTIFIED` rather than enqueuing, so
+//! it is never lost: the poll owner re-polls inline (bounded by
+//! `ASYNC_INLINE_REPOLL_LIMIT`) or reschedules. The future is dropped once, by
+//! the `future_present` flag: the poll owner drops it on completion and `Drop`
+//! (reached only after the last `Arc`, whose refcount release/acquire orders the
+//! owner's write before the destructor's read) skips an already-dropped future.
+
 use std::{
     cell::UnsafeCell,
     future::Future,


### PR DESCRIPTION
Third increment of the moirai unsafe audit — `moirai-executor/src/hybrid/async_state.rs`, the async future state machine. 9 unsafe blocks polling a `!Sync` future held in `UnsafeCell`s reachable from every `Arc` clone. This is the highest-defect-potential file so far: a state-machine bug means concurrent polling (data race) or use-after-complete.

## Audit result: clean

I traced the full lifecycle and confirmed each invariant:

- **Exclusive polling**: `poll()` claims the future only after winning the `QUEUED → POLLING` compare-exchange; the loser returns without touching anything. Wakers on other threads only load/CAS the atomic `state` — they never read the future/lifecycle/result_sender cells — so every `UnsafeCell` dereference is single-threaded despite the shared `Arc`. The `&mut` to the pinned future is dropped before any state transition, so no successor poll can observe it.
- **No lost wakeup**: a wake arriving mid-poll CASes `POLLING → NOTIFIED` instead of enqueuing; `finish_pending_poll` re-polls inline (bounded) or reschedules. A wake after the poll finishes sees `IDLE` and enqueues normally.
- **Single drop**: the `future_present` flag drops the future exactly once — the poll owner on Ready/panic/cancel, and `Drop` (reached only after the last `Arc`, whose refcount release/acquire orders the owner's write before the destructor's read) skips an already-dropped future.

No defect found.

## The gap: the invariant was implicit

Every per-site `Safety` comment appeals to "the single poll owner selected by the async state machine", but the state machine that *selects* that owner was never described centrally. This adds a module doc with the state diagram and the exclusivity, wakeup, and single-drop invariants — the async-task analog of the memory-ordering section from PR #87 (deque) and the disjoint-partition section from PR #88 (parallel ops).

## Verification

Documentation only — no code changed. `moirai-executor` fmt, `clippy -D warnings`, 89 nextest, and the **warning-denied doc build** all pass. (Per the doc-gate discipline, the private-item references are code spans, not intra-doc links — I verified locally before pushing.)

Audit progress: three moirai files (deque, parallel ops, async state), all clean — the mature, well-tested core is sound but was under-centralized in its safety documentation. Next: `moirai-async/src/executor/result_slot.rs` (the cross-task result handoff) and the pal/epoll FFI.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive module-level documentation to the async future state machine, explaining the exclusivity invariant that ensures safe concurrent access to `!Sync` futures held in `UnsafeCell`s. The documentation describes the state machine transitions, how the `QUEUED → POLLING` compare-exchange selects a single poll owner, the no-lost-wakeup guarantee, and the single-drop semantics. This is a documentation-only change with no code modifications, addressing an audit finding that the state machine's safety guarantees were previously only implicit in per-site comments.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-executor/src/hybrid/async_state.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation explaining asynchronous future state transitions, polling ownership, and wakeup handling.
  * Clarified the state machine’s lifecycle and concurrency invariants for easier maintenance and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->