### PR TITLE
Document AsyncResultSlot SPSC protocol and add loom model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,7 @@ dependencies = [
  "criterion",
  "futures",
  "libc",
+ "loom",
  "moirai-async-macros",
  "moirai-core",
  "moirai-executor",

--- a/moirai-async/Cargo.toml
+++ b/moirai-async/Cargo.toml
@@ -31,6 +31,10 @@ criterion = { workspace = true }
 proptest = { workspace = true }
 tempfile = "3.0"
 
+# loom model checker — only compiled under `--cfg loom` (see tests/loom_result_slot.rs).
+[target.'cfg(loom)'.dev-dependencies]
+loom = { workspace = true }
+
 [features]
 default = ["parallel", "mnemosyne-memory"]
 parallel = []
@@ -39,3 +43,8 @@ io = []
 timers = []
 metrics = ["moirai-core/metrics"]
 tokio-compat = ["dep:tokio_dep"]
+
+# Register the `loom` cfg so the -D warnings gate stays clean (it is set via
+# `RUSTFLAGS="--cfg loom"`, not a Cargo feature).
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/moirai-async/src/executor/handle.rs
+++ b/moirai-async/src/executor/handle.rs
@@ -29,6 +29,11 @@ impl<T> Future for AsyncHandle<T> {
 
         self.result_slot.register_waker(cx.waker());
 
+        // Re-check is mandatory, not defensive: a `complete` that raced in on the
+        // slot's PENDING->WRITING path does not wake (no waker was registered when
+        // it ran), so this second take is what closes the lost-wakeup window. See
+        // the `result_slot` module docs.
+
         self.result_slot
             .try_take_ready()
             .map_or(Poll::Pending, Poll::Ready)

--- a/moirai-async/src/executor/result_slot.rs
+++ b/moirai-async/src/executor/result_slot.rs
@@ -1,3 +1,65 @@
+//! Single-producer/single-consumer result slot backing one `AsyncHandle`.
+//!
+//! `AsyncResultSlot` hands a task's output from the executor (the **producer**,
+//! which calls `complete` exactly once) to the awaiting `AsyncHandle` future (the
+//! **consumer**, which calls `try_take_ready` / `register_waker` from `poll`). The
+//! slot lives in an `Arc` shared by exactly those two owners, so the `result` and
+//! `waiter` cells need no lock:
+//!
+//! - the producer runs once — the wrapped future's tail, `let r = fut.await;
+//!   slot.complete(r);`;
+//! - the consumer is serialized with itself, because `poll` takes `Pin<&mut Self>`,
+//!   so no two `try_take_ready` / `register_waker` calls overlap;
+//! - `Drop` runs only after the last `Arc`, so it has exclusive access and races
+//!   neither side.
+//!
+//! # State machine
+//!
+//! `state: AtomicU8` is the sole synchronization variable; the `result` and
+//! `waiter` cells are touched only while a transition grants exclusive access to
+//! them (C = consumer, P = producer):
+//!
+//! ```text
+//!   PENDING ──C register──▶ WAITING ──C re-poll──▶ UPDATING_WAKER ──C──▶ WAITING
+//!      │                       │
+//!      │ P complete            │ P complete
+//!      ▼                       ▼
+//!   WRITING ────────────────▶ WRITING ──P──▶ READY ──C take──▶ TAKEN
+//! ```
+//!
+//! `WRITING` is the producer's exclusive claim on `result`, and `READY` publishes
+//! it; `UPDATING_WAKER` is the consumer's exclusive claim on `waiter` while it
+//! swaps a stale waker, past which the producer spins.
+//!
+//! # Cell-access invariants (what the per-site `// Safety:` comments rely on)
+//!
+//! 1. **`result`: written once, read once.** Only the producer writes it, only
+//!    under `WRITING` (entered by winning the producer CAS, so no consumer can see
+//!    it yet). It is read exactly once — by the unique `READY -> TAKEN` consumer
+//!    CAS, or by `Drop` at `READY` when the consumer never took it.
+//! 2. **`waiter`: written by the consumer, read once by the producer.** The
+//!    consumer writes it under `PENDING` (published by the `PENDING -> WAITING`
+//!    release CAS) or under the `UPDATING_WAKER` lock. The producer reads it
+//!    exactly once, on `WAITING -> WRITING`; otherwise `Drop` at `WAITING` drops
+//!    it. A *failed* publish CAS proves no producer observed the write, so the
+//!    consumer drops its own clone.
+//! 3. **No lost wakeup — a contract shared with `AsyncHandle::poll`.** `complete`
+//!    on the `PENDING -> WRITING` path (it beat registration) deliberately does
+//!    not wake: no waker is registered yet. Liveness therefore requires the
+//!    consumer to check → `register_waker` → **re-check**; should `complete` land
+//!    in that window, the re-check observes `READY`. That re-check is load-bearing,
+//!    not defensive — dropping it reintroduces a hang.
+//!
+//! # Ordering
+//!
+//! Each cell access is ordered by a release/acquire pair on `state`: the writer
+//! releases on the publishing transition, the reader acquires on the transition
+//! that reads the cell. Thus `PENDING -> WAITING` and the `UPDATING_WAKER ->
+//! WAITING` store are `Release` (they publish `waiter`), while `WAITING -> WRITING`
+//! and `READY -> TAKEN` are `Acquire` (they read a cell). The `PENDING -> WRITING`
+//! success is `Relaxed`: that path reads neither cell before its own `store(READY,
+//! Release)` publishes `result`, so it carries no incoming edge to establish.
+
 use std::{
     cell::UnsafeCell,
     mem::MaybeUninit,

--- a/moirai-async/tests/loom_result_slot.rs
+++ b/moirai-async/tests/loom_result_slot.rs
@@ -1,0 +1,266 @@
+//! loom exhaustive-interleaving model of `AsyncResultSlot`'s producer/consumer
+//! protocol (`moirai-async/src/executor/result_slot.rs`).
+//!
+//! The production slot backs its `result`/`waiter` payload with
+//! `UnsafeCell<MaybeUninit<_>>`; this file models the *state protocol* — the
+//! six-state `AtomicU8` and the exact `Acquire`/`Release`/`Relaxed` orderings of
+//! `complete`, `try_take_ready`, and `register_waker` — over loom-tracked cells,
+//! plus the `check -> register -> re-check` sequence that `AsyncHandle::poll`
+//! wraps them in. loom enumerates every producer/consumer interleaving and checks
+//! the two invariants the hand proof in `result_slot.rs` claims:
+//!
+//! - **exactly-once**: the result is delivered once — never lost, never taken
+//!   twice;
+//! - **no lost wakeup**: a consumer that parks (polls to `Pending`) is always
+//!   woken, so it is guaranteed to be re-polled and take the result.
+//!
+//! loom's `UnsafeCell` additionally fails the run on any unsynchronized access to
+//! the `result`/`waiter` cells, so the model also proves the state transitions
+//! serialize every cell access (the property the per-site `// Safety:` comments
+//! assert).
+//!
+//! Keep the orderings here in sync with the production code: any change to the
+//! `Acquire`/`Release`/`Relaxed` on `state`, or to the poll sequence, must be
+//! mirrored.
+//!
+//! Run with:
+//! `RUSTFLAGS="--cfg loom" cargo test -p moirai-async --test loom_result_slot --release`
+//!
+//! Under a normal build the `#![cfg(loom)]` gate makes this file empty, so it
+//! never affects the standard test suite or pulls in the `loom` dependency.
+
+#![cfg(loom)]
+
+use loom::cell::UnsafeCell;
+use loom::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use loom::sync::Arc;
+use loom::thread;
+
+const PENDING: u8 = 0;
+const WAITING: u8 = 1;
+const UPDATING_WAKER: u8 = 2;
+const WRITING: u8 = 3;
+const READY: u8 = 4;
+const TAKEN: u8 = 5;
+
+const VALUE: u32 = 0xA5A5_5A5A;
+
+/// Model of `AsyncResultSlot<u32>`: the `state` atomic plus the two payload
+/// cells, using the production orderings. `woken` models the effect of
+/// `Waker::wake` so the no-lost-wakeup invariant is observable after the run.
+struct Slot {
+    result: UnsafeCell<Option<u32>>,
+    state: AtomicU8,
+    /// `true` == a waker is currently registered in the cell.
+    waiter: UnsafeCell<bool>,
+    woken: AtomicBool,
+}
+
+impl Slot {
+    fn new() -> Self {
+        Self {
+            result: UnsafeCell::new(None),
+            state: AtomicU8::new(PENDING),
+            waiter: UnsafeCell::new(false),
+            woken: AtomicBool::new(false),
+        }
+    }
+
+    /// Mirror of `AsyncResultSlot::complete` + `begin_completion`. Returns whether
+    /// it observed a registered waiter (the `waiting` branch).
+    fn complete(&self, value: u32) -> bool {
+        let waiting = loop {
+            match self.state.load(Ordering::Acquire) {
+                PENDING => {
+                    if self
+                        .state
+                        .compare_exchange(PENDING, WRITING, Ordering::Relaxed, Ordering::Acquire)
+                        .is_ok()
+                    {
+                        break false;
+                    }
+                }
+                WAITING => {
+                    if self
+                        .state
+                        .compare_exchange(WAITING, WRITING, Ordering::Acquire, Ordering::Acquire)
+                        .is_ok()
+                    {
+                        break true;
+                    }
+                }
+                // The consumer holds the waiter cell mid-swap; yield so loom
+                // advances the consumer instead of enumerating unbounded spin
+                // iterations (the production code spins with `spin_loop`).
+                UPDATING_WAKER => thread::yield_now(),
+                // A single producer completes once, so it never observes its own
+                // WRITING or the post-completion READY/TAKEN at the loop head.
+                other => unreachable!("producer saw unexpected state {other}"),
+            }
+        };
+
+        // WRITING is exclusive to this producer: initialize the result cell.
+        self.result.with_mut(|p| unsafe { *p = Some(value) });
+        self.state.store(READY, Ordering::Release);
+
+        if waiting {
+            // WAITING -> WRITING acquired the consumer's release of the waiter;
+            // read it exactly once and model the wake.
+            let registered = self.waiter.with_mut(|p| unsafe {
+                let was = *p;
+                *p = false; // assume_init_read moves the waker out of the cell
+                was
+            });
+            assert!(registered, "producer read an unregistered waiter cell");
+            self.woken.store(true, Ordering::Release);
+        }
+        waiting
+    }
+
+    /// Mirror of `AsyncResultSlot::try_take_ready`.
+    fn try_take_ready(&self) -> Option<u32> {
+        if self
+            .state
+            .compare_exchange(READY, TAKEN, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            // READY -> TAKEN is the unique consumer transition: read once.
+            self.result.with_mut(|p| unsafe { (*p).take() })
+        } else {
+            None
+        }
+    }
+
+    /// Mirror of `AsyncResultSlot::register_waker`.
+    fn register_waker(&self) {
+        loop {
+            match self.state.load(Ordering::Acquire) {
+                PENDING => {
+                    self.waiter.with_mut(|p| unsafe { *p = true });
+                    if self
+                        .state
+                        .compare_exchange(PENDING, WAITING, Ordering::Release, Ordering::Acquire)
+                        .is_ok()
+                    {
+                        return;
+                    }
+                    // Publish failed: no producer observed this write, so drop it.
+                    self.waiter.with_mut(|p| unsafe { *p = false });
+                }
+                WAITING => {
+                    if self
+                        .state
+                        .compare_exchange(
+                            WAITING,
+                            UPDATING_WAKER,
+                            Ordering::Acquire,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        // UPDATING_WAKER excludes the producer: swap the stale
+                        // waker for the fresh one.
+                        self.waiter.with_mut(|p| unsafe {
+                            *p = false; // drop stale
+                            *p = true; // write fresh
+                        });
+                        self.state.store(WAITING, Ordering::Release);
+                        return;
+                    }
+                }
+                // WRITING (producer writing) or UPDATING_WAKER (unreachable with a
+                // single consumer): yield so loom advances the producer instead of
+                // enumerating unbounded spin iterations.
+                WRITING | UPDATING_WAKER => thread::yield_now(),
+                // READY / TAKEN: the result is already available; do not register.
+                _ => return,
+            }
+        }
+    }
+}
+
+/// The consumer's `AsyncHandle::poll` body: check, register, re-check.
+fn poll(slot: &Slot) -> Option<u32> {
+    if let Some(v) = slot.try_take_ready() {
+        return Some(v);
+    }
+    slot.register_waker();
+    slot.try_take_ready()
+}
+
+/// Assert exactly-once delivery and no lost wakeup after both threads join.
+///
+/// `took` is what the consumer's `poll` returned across the run.
+fn assert_delivered_once(slot: &Slot, took: Option<u32>) {
+    match took {
+        Some(v) => {
+            // Delivered straight to a poll. Exactly-once: nothing remains.
+            assert_eq!(v, VALUE);
+            assert_eq!(slot.try_take_ready(), None, "result taken twice");
+        }
+        None => {
+            // Parked. No lost wakeup: the consumer must have been woken, and the
+            // guaranteed re-poll takes the single result.
+            assert!(
+                slot.woken.load(Ordering::Relaxed),
+                "lost wakeup: consumer parked but was never woken"
+            );
+            assert_eq!(slot.try_take_ready(), Some(VALUE), "result lost");
+            assert_eq!(slot.try_take_ready(), None, "result taken twice");
+        }
+    }
+}
+
+/// `complete` races a single `poll` (check -> register -> re-check).
+#[test]
+fn complete_races_first_poll() {
+    loom::model(|| {
+        let slot = Arc::new(Slot::new());
+
+        let producer = {
+            let slot = Arc::clone(&slot);
+            thread::spawn(move || slot.complete(VALUE))
+        };
+        let consumer = {
+            let slot = Arc::clone(&slot);
+            thread::spawn(move || poll(&slot))
+        };
+
+        producer.join().unwrap();
+        let took = consumer.join().unwrap();
+
+        // Both children joined: the main thread now has exclusive access.
+        assert_delivered_once(&slot, took);
+    });
+}
+
+/// `complete` races a consumer that polls twice, so the second poll re-registers
+/// through `WAITING -> UPDATING_WAKER -> WAITING` against the producer — exercising
+/// the waiter-swap-under-lock and the producer's spin past `UPDATING_WAKER`.
+#[test]
+fn complete_races_reregistering_poll() {
+    loom::model(|| {
+        let slot = Arc::new(Slot::new());
+
+        let producer = {
+            let slot = Arc::clone(&slot);
+            thread::spawn(move || slot.complete(VALUE))
+        };
+        let consumer = {
+            let slot = Arc::clone(&slot);
+            thread::spawn(move || {
+                if let Some(v) = poll(&slot) {
+                    return Some(v);
+                }
+                // A spurious re-poll is always permitted; here it drives the
+                // re-registration path.
+                poll(&slot)
+            })
+        };
+
+        producer.join().unwrap();
+        let took = consumer.join().unwrap();
+
+        assert_delivered_once(&slot, took);
+    });
+}


### PR DESCRIPTION
Fourth increment of the moirai unsafe audit — `moirai-async/src/executor/result_slot.rs`, the oneshot result handoff behind every `AsyncHandle`. 8 unsafe blocks over a single-producer/single-consumer slot: the completing task writes a `MaybeUninit` result and the awaiting `poll` takes it, coordinated by a six-state `AtomicU8` and two `UnsafeCell`s (result + registered `Waker`). This is the classic oneshot-with-waker shape — the most race-prone primitive in the crate (lost wakeup, waiter-cell data race, double-take/double-drop).

## Audit result: sound

Traced every producer/consumer interleaving. The consumer's own calls are serialized (`poll` takes `Pin<&mut Self>`), and the slot is `Arc`-shared by exactly the producer and consumer, so `Drop` is exclusive.

- **`result` written once, read once**: only the producer writes it, under WRITING (the winning producer transition, before any consumer can observe it); read exactly once at READY→TAKEN (unique consumer CAS) or by `Drop` at READY.
- **`waiter` written by consumer, read once by producer**: written under PENDING (published by the PENDING→WAITING release CAS) or under the UPDATING_WAKER lock; read once on WAITING→WRITING, else dropped by `Drop` at WAITING. A *failed* publish CAS proves no producer observed the write, so the consumer drops its own clone.
- **No lost wakeup**: `complete` on the PENDING→WRITING path (it beat registration) deliberately does not wake — no waker is registered yet — so liveness rests on the consumer's check→register→**re-check** (`AsyncHandle::poll`); if `complete` lands in that window, the re-check observes READY.
- **Orderings** are the weakest sufficient: Relaxed on PENDING→WRITING (reads no cell before its own `store(READY, Release)`), Acquire on the cell-reading transitions (WAITING→WRITING, READY→TAKEN), Release on the publishing ones.

No defect found.

## Changes

- **docs**: a module doc centralizing the SPSC model, the state diagram, the two cell-access invariants every per-site `// Safety:` comment relies on, and the ordering rationale — plus a comment marking the re-check in `AsyncHandle::poll` as load-bearing, so the no-lost-wakeup contract (which spans the two files) survives future edits.
- **test**: `tests/loom_result_slot.rs` — two `#![cfg(loom)]` interleaving models (a single poll racing `complete`; a re-registering poll driving the WAITING→UPDATING_WAKER waiter swap against the producer) that enumerate every interleaving and assert exactly-once delivery + no lost wakeup. loom's `UnsafeCell` tracking additionally proves the state machine serializes every cell access. Wired like the deque model (`moirai-scheduler`): cfg(loom) dev-dep + check-cfg registration, empty under normal builds.

Unlike the deque, this slot previously had **no** loom coverage despite being the crate's most race-critical primitive — this closes that gap. No production code changed.

## Verification

- `cargo fmt` ✓
- `cargo nextest run -p moirai-async` — 86/86 ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-async` ✓ (private-item references are code spans, not intra-doc links, per the doc-gate discipline)
- `RUSTFLAGS="--cfg loom" cargo test -p moirai-async --test loom_result_slot --release` — both models pass, exhaustive (0.58s)

## Note

`cargo clippy -p moirai-async --all-targets` surfaces 7 pre-existing `manual_noop_waker` findings (clippy 1.97; `condvar.rs` + six test modules) — unrelated to this change, not in any touched file, and not CI-gated (CI clippy is scoped to `moirai-python`). Filed for a follow-up [patch] replacing the manual `NoopWake` impls with `Waker::noop()`.

Audit progress: four moirai files (deque, parallel ops, async state, result slot), all sound — the mature core is race-free but was under-centralized in its safety documentation and, here, under-covered by model checking.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive documentation and formal verification for `AsyncResultSlot`, a lock-free single-producer/single-consumer primitive that handles result delivery between task completion and `AsyncHandle` awaiting. The changes include detailed documentation of the six-state atomic protocol, cell-access invariants, and memory ordering rationale, plus two exhaustive loom models that verify exactly-once delivery and no lost wakeup across all possible interleavings. A load-bearing comment is added to `AsyncHandle::poll` marking the mandatory re-check that prevents lost wakeups. No production logic is modified—this is purely a documentation and testing enhancement to close a verification gap in the crate's most race-critical primitive.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-async/src/executor/result_slot.rs` |
| 2 | `moirai-async/src/executor/handle.rs` |
| 3 | `moirai-async/tests/loom_result_slot.rs` |
| 4 | `moirai-async/Cargo.toml` |
| 5 | `Cargo.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->