### PR TITLE
Replace manual no-op wakers with Waker::noop()

### DIFF
--- a/moirai-async/src/sync/condvar.rs
+++ b/moirai-async/src/sync/condvar.rs
@@ -1,19 +1,13 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll, Wake, Waker};
+use std::task::{Context, Poll, Waker};
 
 use crate::sync::wait_queue::{WaitQueue, WaiterPoll};
 
 use super::mutex::{Mutex, MutexGuard};
 
-struct NoopWaker;
-impl Wake for NoopWaker {
-    fn wake(self: Arc<Self>) {}
-}
-
 fn noop_waker() -> Waker {
-    Waker::from(Arc::new(NoopWaker))
+    Waker::noop().clone()
 }
 
 pub struct Condvar {

--- a/moirai-async/src/sync/mpsc.rs
+++ b/moirai-async/src/sync/mpsc.rs
@@ -260,14 +260,8 @@ mod tests {
     };
     use std::task::{Context, Poll, Wake, Waker};
 
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
-
     fn poll_future<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
         Pin::new(future).poll(&mut context)
     }
 

--- a/moirai-async/src/sync/mutex.rs
+++ b/moirai-async/src/sync/mutex.rs
@@ -147,17 +147,10 @@ mod tests {
     use super::Mutex;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
-
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
+    use std::task::{Context, Poll, Waker};
 
     fn poll_future<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
         Pin::new(future).poll(&mut context)
     }
 

--- a/moirai-async/src/sync/oneshot.rs
+++ b/moirai-async/src/sync/oneshot.rs
@@ -141,17 +141,10 @@ mod tests {
     use super::*;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
-
-    struct NoopWake;
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
+    use std::task::{Context, Poll, Waker};
 
     fn poll_future<F: Future + Unpin>(future: &mut F) -> Poll<F::Output> {
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
         Pin::new(future).poll(&mut context)
     }
 

--- a/moirai-async/src/sync/rwlock.rs
+++ b/moirai-async/src/sync/rwlock.rs
@@ -299,21 +299,13 @@ mod tests {
     use super::RwLock;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
-
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
+    use std::task::{Context, Poll, Waker};
 
     fn poll_future<F>(future: &mut F) -> Poll<F::Output>
     where
         F: Future + Unpin,
     {
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
         Pin::new(future).poll(&mut context)
     }
 

--- a/moirai-async/src/sync/wait_queue.rs
+++ b/moirai-async/src/sync/wait_queue.rs
@@ -168,17 +168,10 @@ impl<G> WaitQueue<G> {
 #[cfg(test)]
 mod tests {
     use super::{WaitQueue, WaiterPoll};
-    use std::sync::Arc;
-    use std::task::{Wake, Waker};
-
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
+    use std::task::Waker;
 
     fn noop_waker() -> Waker {
-        Waker::from(Arc::new(NoopWake))
+        Waker::noop().clone()
     }
 
     #[test]

--- a/moirai-async/src/timer/driver.rs
+++ b/moirai-async/src/timer/driver.rs
@@ -183,15 +183,8 @@ mod tests {
     use crate::timer::Delay;
     use std::future::Future;
     use std::pin::Pin;
-    use std::sync::Arc;
-    use std::task::{Context, Wake, Waker};
+    use std::task::{Context, Waker};
     use std::time::Duration;
-
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
 
     #[test]
     fn cancelled_timers_are_compacted_before_their_deadline() {
@@ -208,8 +201,7 @@ mod tests {
         // Pre-existing timer registrations are permitted, so the bound tracks
         // the measured initial heap size instead of assuming process-global
         // isolation from other timer coverage.
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = Context::from_waker(Waker::noop());
 
         // Measure the driver's initial state; other tests may have left timers
         // in the process-global driver, so all assertions are relative.


### PR DESCRIPTION
Follow-up to #90, which surfaced these while auditing `result_slot`.

Seven sites hand-rolled a `NoopWake`/`NoopWaker` unit struct with an empty `impl Wake` purely to build a `Context`: `sync/condvar.rs` (the live `Condvar::wait` registration path — not test-only), plus the test modules of `sync/mpsc.rs`, `sync/mutex.rs`, `sync/oneshot.rs`, `sync/rwlock.rs`, `sync/wait_queue.rs`, and `timer/driver.rs`.

`Waker::noop()` is the std spelling — a `&'static Waker`, no allocation, no `Arc`, no type to declare. Stable since 1.85; this repo's `rust-toolchain.toml` pins 1.95, so it is well within the floor.

## Why now

These are the seven `clippy::manual_noop_waker` findings that appear under clippy 1.97, so `cargo clippy -p moirai-async --all-targets -- -D warnings` is now clean. (They are not currently CI-gated — `python-ci.yml` scopes clippy to `moirai-python` at the pinned 1.95 — so this is debt cleared ahead of the lint reaching the pinned toolchain, not a broken gate.)

## Notes

- Net −49 lines.
- `CountingWake` in `mpsc.rs` is a **real** counting waker used by the wake-accounting tests; untouched.
- Behavior is unchanged: an empty `Wake::wake` and the std no-op waker are the same no-op. The two `noop_waker()` helpers (condvar, wait_queue) keep their signature and return an owned `Waker` via `Waker::noop().clone()`; the four `poll_future` helpers take the `&'static` reference directly.
- Import cleanup follows: `Wake`/`Arc` dropped where they were only there for the removed struct, `Waker` retained where `Waker::noop()` needs it — `mpsc.rs` keeps all three for `CountingWake`.

## Verification

- `cargo fmt -p moirai-async -- --check` ✓
- `cargo clippy -p moirai-async --all-targets -- -D warnings` ✓ (was 7 errors, now clean)
- `cargo nextest run -p moirai-async` — 86/86 ✓

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR replaces seven hand-rolled no-op waker implementations with the standard library's `Waker::noop()` method, which has been stable since Rust 1.85. The changes affect one production code path in `sync/condvar.rs` and six test modules across various synchronization primitives. The refactoring eliminates custom `NoopWaker`/`NoopWake` unit structs and their `impl Wake` blocks, replacing them with direct calls to `Waker::noop()`. This cleanup removes 49 lines of code and addresses seven `clippy::manual_noop_waker` lint warnings while maintaining identical runtime behavior.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-async/src/sync/condvar.rs` |
| 2 | `moirai-async/src/sync/wait_queue.rs` |
| 3 | `moirai-async/src/sync/mpsc.rs` |
| 4 | `moirai-async/src/sync/mutex.rs` |
| 5 | `moirai-async/src/sync/oneshot.rs` |
| 6 | `moirai-async/src/sync/rwlock.rs` |
| 7 | `moirai-async/src/timer/driver.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->