### PR TITLE
Validate segment size when opening shared memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep stack-owned scheduler scope state alive until the final completion
   releases its wait synchronization, preventing a multi-job scoped fan-out from
   hanging or dereferencing destroyed state.
+- Reject a Unix `SharedMemory::open` whose requested size exceeds the existing
+  segment. `mmap` accepts a length past the end of the object and leaves the
+  surplus pages unbacked, so `as_slice` handed out bytes that raise `SIGBUS` on
+  read; `open` now checks the segment with `fstat` first. Windows already
+  refused the oversized view in `MapViewOfFile`.
+- Test the async task completion flag under the future lock rather than before
+  acquiring it, so a second thread polling the same executor cannot pass the
+  check, wait for the lock, and then poll a future that completed meanwhile —
+  which panics with "resumed after completion".
 
 ## [0.4.0] - 2026-07-17
 

--- a/moirai-core/src/ipc/memory.rs
+++ b/moirai-core/src/ipc/memory.rs
@@ -1,3 +1,48 @@
+//! OS shared-memory segments: POSIX `shm_open`/`mmap` and Win32 file mappings.
+//!
+//! [`SharedMemory`] owns one mapping of `size` bytes at `ptr`, valid until
+//! `Drop` unmaps it. It is the raw substrate under
+//! [`SharedQueue`](super::SharedQueue); the two contracts below are what make
+//! its safe API sound.
+//!
+//! # The mapping must cover `size`
+//!
+//! `as_slice`/`as_mut_slice` build a slice of exactly `size` bytes, so the
+//! mapping has to be backed for all of them. The two platforms differ in who
+//! enforces that, and the difference is why `open` is written the way it is:
+//!
+//! - **Windows** enforces it. `MapViewOfFile` requires the requested view to lie
+//!   within the mapping object, and fails otherwise, so an oversized `open` is
+//!   rejected by the OS.
+//! - **POSIX does not.** `mmap` accepts a length running past the end of the
+//!   object; the pages beyond it simply are not backed, and touching them raises
+//!   `SIGBUS`. `open` therefore `fstat`s the descriptor and rejects a segment
+//!   smaller than `size` itself — without that check a caller could open an
+//!   existing segment under a too-large `size` and get a slice that faults on
+//!   read. `create` needs no such check because its `ftruncate` sets the object
+//!   to exactly `size`.
+//!
+//! The POSIX check reads the size from the descriptor it goes on to map, so it
+//! cannot be defeated by re-resolving the name. It does not cover a process that
+//! *shrinks* the object with `ftruncate` after the check — an act that already
+//! invalidates every existing mapping of that segment, and which POSIX gives no
+//! way to exclude.
+//!
+//! # Cross-process aliasing is the caller's contract
+//!
+//! A segment is shared by construction: another process holding the same name
+//! may write it at any time. `&[u8]` and `&mut [u8]` promise Rust that no such
+//! concurrent write happens, and no OS primitive here can enforce that. The safe
+//! accessors therefore carry a contract the caller must uphold — either be the
+//! only party touching the bytes for the borrow, or coordinate externally.
+//! [`SharedQueue`](super::SharedQueue) is the coordinated wrapper: it never hands
+//! out a slice, reaching the bytes through raw pointers with the atomic head/tail
+//! protocol in its metadata header instead.
+//!
+//! Ownership is separate from mapping: `owner` records who created the segment,
+//! so only the creator `shm_unlink`s the name on drop. Every handle unmaps its
+//! own view and closes its own descriptor regardless.
+
 use super::error::{last_os_error, IpcError};
 use core::slice;
 
@@ -68,7 +113,16 @@ fn unix_mapping_length(size: usize) -> Result<libc::off_t, IpcError> {
     libc::off_t::try_from(size).map_err(|_| IpcError::InvalidArgument)
 }
 
+// SAFETY: the mapping is process-wide, not thread-owned — `ptr` stays valid on
+// any thread for the lifetime of this handle, and neither the descriptor nor the
+// handle is thread-affine. `Send` therefore moves a still-valid mapping.
 unsafe impl Send for SharedMemory {}
+
+// SAFETY: `&SharedMemory` reaches only `as_slice`, which performs no interior
+// mutation, so sharing the handle across threads adds no race the type does not
+// already have. In-process `&mut` access is excluded by the borrow checker via
+// `as_mut_slice(&mut self)`; concurrent writes from *other processes* are outside
+// what any impl here can enforce and are the caller's contract (see module docs).
 unsafe impl Sync for SharedMemory {}
 
 impl SharedMemory {
@@ -121,19 +175,42 @@ impl SharedMemory {
         }
     }
 
-    /// Open an existing shared memory segment
+    /// Open an existing shared memory segment.
+    ///
+    /// Fails with [`IpcError::InvalidArgument`] if the segment is smaller than
+    /// `size`. `mmap` accepts a length past the end of the object, but the pages
+    /// beyond it are not backed: reading them raises `SIGBUS`, so an unchecked
+    /// mapping would hand out an `as_slice` that faults instead of reading.
     #[cfg(unix)]
     pub fn open(name: &str, size: usize) -> Result<Self, IpcError> {
         use std::ffi::CString;
 
+        let mapping_length = unix_mapping_length(size)?;
         let c_name = CString::new(name).map_err(|_| IpcError::InvalidArgument)?;
 
+        // SAFETY: `c_name` is NUL-terminated and `mapping_length` is positive and
+        // representable as `off_t`. The descriptor is closed on every failure
+        // path, and the mapping is only kept once `fstat` proves the object
+        // covers all `size` bytes.
         unsafe {
             use std::ptr::null_mut;
             let fd = libc::shm_open(c_name.as_ptr(), libc::O_RDWR, 0);
 
             if fd < 0 {
                 return Err(last_os_error());
+            }
+
+            let mut segment = core::mem::MaybeUninit::<libc::stat>::uninit();
+            if libc::fstat(fd, segment.as_mut_ptr()) < 0 {
+                let error = last_os_error();
+                libc::close(fd);
+                return Err(error);
+            }
+
+            // `fstat` succeeded, so the OS initialized the struct.
+            if segment.assume_init().st_size < mapping_length {
+                libc::close(fd);
+                return Err(IpcError::InvalidArgument);
             }
 
             let ptr = libc::mmap(
@@ -175,6 +252,9 @@ impl SharedMemory {
         #[allow(clippy::cast_possible_truncation)]
         let size_low = size as u32;
         let size_high = (size as u64 >> 32) as u32;
+        // SAFETY: `wide` is a NUL-terminated UTF-16 name that outlives the call,
+        // and the size pair describes `size` bytes. The handle is closed if the
+        // view fails to map, so no failure path leaks it.
         unsafe {
             let handle = win::CreateFileMappingW(
                 win::INVALID_HANDLE_VALUE,
@@ -212,6 +292,10 @@ impl SharedMemory {
         }
         let wide = win::wide_name(name);
 
+        // SAFETY: `wide` is a NUL-terminated UTF-16 name that outlives the call.
+        // `MapViewOfFile` rejects a view larger than the mapping object, so a
+        // successful return proves all `size` bytes are backed; the handle is
+        // closed on the failure path.
         unsafe {
             let handle = win::OpenFileMappingW(win::FILE_MAP_ALL_ACCESS, 0, wide.as_ptr());
             if handle == 0 {
@@ -234,19 +318,37 @@ impl SharedMemory {
         }
     }
 
-    /// Get a slice of the shared memory
+    /// Get a slice of the shared memory.
+    ///
+    /// The borrow assumes no other process writes the segment while it is held
+    /// (see the module docs); use [`SharedQueue`](super::SharedQueue) when
+    /// another process is an active writer.
     pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: `ptr` is a live mapping of `size` bytes — `create` sized the
+        // object with `ftruncate` and `open` rejected a segment smaller than
+        // `size` — so every byte is backed and readable, and `u8` needs no
+        // alignment beyond the page-aligned base. Absence of a concurrent
+        // cross-process writer is the caller's contract.
         unsafe { slice::from_raw_parts(self.ptr, self.size) }
     }
 
-    /// Get a mutable slice of the shared memory
+    /// Get a mutable slice of the shared memory.
+    ///
+    /// The borrow assumes no other process reads or writes the segment while it
+    /// is held (see the module docs).
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: as `as_slice`, and `&mut self` excludes any other in-process
+        // borrow of the same mapping for the lifetime of the returned slice.
         unsafe { slice::from_raw_parts_mut(self.ptr, self.size) }
     }
 }
 
 impl Drop for SharedMemory {
     fn drop(&mut self) {
+        // SAFETY: `&mut self` in `drop` is exclusive, and `ptr`/`size` are the
+        // exact base and length this handle mapped, so `munmap` releases its own
+        // view and nothing else. The name is unlinked only by the creator, so a
+        // handle from `open` never removes a segment others still use.
         #[cfg(unix)]
         unsafe {
             libc::munmap(self.ptr as *mut libc::c_void, self.size);
@@ -257,6 +359,10 @@ impl Drop for SharedMemory {
                 }
             }
         }
+        // SAFETY: `&mut self` in `drop` is exclusive; `ptr` is the base this
+        // handle received from `MapViewOfFile` and `handle` the mapping it came
+        // from, so each is released exactly once. The mapping object outlives
+        // this close while any other process still holds it open.
         #[cfg(windows)]
         unsafe {
             win::UnmapViewOfFile(self.ptr as *const core::ffi::c_void);

--- a/moirai-core/src/ipc/tests.rs
+++ b/moirai-core/src/ipc/tests.rs
@@ -33,6 +33,46 @@ fn zero_size_segment_is_rejected() {
     assert!(matches!(result, Err(IpcError::InvalidArgument)));
 }
 
+#[test]
+fn open_larger_than_the_segment_is_rejected() {
+    // A mapping must cover every byte `as_slice` hands out. POSIX `mmap` accepts
+    // a length past the end of the object and leaves the surplus pages unbacked,
+    // so reading them raises SIGBUS; `open` has to reject the oversized request
+    // itself. (Win32 `MapViewOfFile` already refuses a view beyond the mapping.)
+    let name = "/moirai_test_open_oversize";
+    let _creator = SharedMemory::create(name, 4096).expect("create must succeed");
+
+    // Far enough past the segment that the surplus is whole unbacked pages, not
+    // the zero-filled tail of the segment's own final page.
+    let result = SharedMemory::open(name, 1 << 20);
+
+    assert!(
+        result.is_err(),
+        "opening a 4 KiB segment as 1 MiB must be rejected, not mapped"
+    );
+
+    // Which error depends on who caught it: POSIX `mmap` would have accepted the
+    // oversized length, so `open` checks the segment itself and reports
+    // `InvalidArgument`; on Windows the refusal comes from `MapViewOfFile` and
+    // surfaces as the OS error.
+    #[cfg(unix)]
+    assert!(matches!(result, Err(IpcError::InvalidArgument)));
+}
+
+#[test]
+fn open_smaller_than_the_segment_maps_a_prefix() {
+    // The size check rejects only mappings the segment cannot back; opening a
+    // prefix stays legal, so the guard above is not simply refusing every open.
+    let name = "/moirai_test_open_prefix";
+    let mut creator = SharedMemory::create(name, 4096).expect("create must succeed");
+    creator.as_mut_slice()[..4].copy_from_slice(b"ipc!");
+
+    let opener = SharedMemory::open(name, 1024).expect("prefix open must succeed");
+
+    assert_eq!(opener.as_slice().len(), 1024);
+    assert_eq!(&opener.as_slice()[..4], b"ipc!");
+}
+
 #[cfg(all(unix, target_pointer_width = "64"))]
 #[test]
 fn segment_larger_than_off_t_is_rejected_before_creation() {


### PR DESCRIPTION
Sixth increment of the moirai unsafe audit — `moirai-core/src/ipc/memory.rs`, the POSIX/Win32 shared-memory primitive. 8 unsafe blocks and 2 `unsafe impl`s with **one** safety comment between them, the thinnest documentation ratio of any file audited so far. It also contains a defect.

## Audit result: one defect (POSIX only)

`SharedMemory::open(name, size)` mapped the caller's `size` without ever consulting the segment it was opening:

```rust
let fd = libc::shm_open(c_name.as_ptr(), libc::O_RDWR, 0);
// ...no size check...
let ptr = libc::mmap(null_mut(), size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
```

POSIX `mmap` **accepts a length running past the end of the object**. The surplus pages are simply not backed, and touching them raises `SIGBUS`. So opening a 4 KiB segment as 1 MiB succeeded, and the resulting `as_slice()` returned a `&[u8]` of 1 MiB whose tail faults on read.

`open` and `as_slice` are both safe `pub fn`s, so safe code alone reaches the faulting slice — a safe API with a soundness obligation it wasn't meeting.

### Windows was already correct

`MapViewOfFile` requires the view to lie within the mapping object and fails otherwise, so the oversized `open` was already rejected there. That asymmetry is why the new check lives only in the Unix path, and it is now stated in the module docs rather than left implicit.

### The hazard was known one layer up

`SharedQueue::open` already defends against this — its doc says a capacity mismatch "would otherwise map a view inconsistent with the creator's **and fault on access**", and it validates a header-recorded capacity before touching data. The wrapper was safe; the public primitive underneath it was not.

## Fix

`open` now `fstat`s the descriptor and rejects a segment smaller than `size`. Routing it through the existing `unix_mapping_length` helper also gives `open` the zero-size rejection and `off_t` conversion that only `create` had.

The check reads the size from the same descriptor it goes on to map, so it cannot be defeated by re-resolving the name. It does not cover a process that *shrinks* the object with `ftruncate` afterwards — an act that already invalidates every existing mapping and which POSIX gives no way to exclude. That limit is documented rather than glossed.

## Tests

Both directions, so the guard is not simply refusing everything:

- `open_larger_than_the_segment_is_rejected` — creates 4 KiB, opens as 1 MiB, must fail. Passes on Windows today (`MapViewOfFile` refuses it); on Linux this is the regression test for the fix. The size is far enough past the segment that the surplus is whole unbacked pages, not the zero-filled tail of the segment's own final page.
- `open_smaller_than_the_segment_maps_a_prefix` — opening a prefix stays legal and reads the creator's bytes.

CI's ubuntu step (`cargo nextest run --locked -p moirai-core --no-default-features --features std`) runs both on Linux.

## Documentation

The file had one safety comment for ten unsafe sites. Adds a module doc for the two contracts the safe API rests on:

1. **The mapping must cover `size`** — including the platform split above and why `create` needs no check (its `ftruncate` sizes the object exactly).
2. **Cross-process aliasing is the caller's contract** — a segment is shared by construction, and `&[u8]`/`&mut [u8]` promise Rust that no concurrent write happens. No OS primitive here can enforce that, so the safe accessors carry a contract, and `SharedQueue` is the coordinated alternative that never hands out a slice.

Plus `SAFETY` comments on every unsafe block and both `unsafe impl`s, including what `Sync` does and does not claim.

## Verification

On Windows (host):
- `cargo fmt -p moirai-core -- --check` ✓
- `cargo clippy -p moirai-core --no-default-features --features std --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-core --no-default-features --features std` — 11/11 ipc tests ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc` ✓

For the Unix path, which the host cannot run: `cargo check -p moirai-core --no-default-features --features std --target x86_64-unknown-linux-gnu` under the pinned 1.95.0 toolchain — **type-checks clean**. Runtime behavior of the new `fstat` guard is verified by the CI ubuntu job.

CHANGELOG: adds this fix, and the task-completion fix from #92 that was omitted from its entry.

Audit progress: six moirai files — four sound (deque, parallel ops, async_state, result_slot), two with defects found and fixed (async task re-entry #92, shared-memory sizing here).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a soundness bug in `SharedMemory::open` on POSIX systems where opening a shared memory segment with a size larger than the actual segment would succeed but produce a slice that triggers `SIGBUS` when accessed. The fix adds an `fstat` check to validate the segment size before mapping, rejecting oversized requests. Windows was already safe due to `MapViewOfFile` rejecting such requests. The PR also adds comprehensive documentation explaining the safety contracts around memory mapping coverage and cross-process aliasing, and includes `SAFETY` comments for all previously undocumented unsafe blocks.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-core/src/ipc/memory.rs` |
| 2 | `moirai-core/src/ipc/tests.rs` |
| 3 | `CHANGELOG.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shared-memory access now rejects mapping requests larger than the available segment, preventing potential runtime faults.
  * Opening a smaller portion of an existing shared-memory segment now works reliably while preserving the requested size.

* **Tests**
  * Added coverage for shared-memory size validation and partial mappings.
  * Improved async task-completion testing to prevent completion-state race regressions.

* **Documentation**
  * Expanded guidance on shared-memory safety, lifetime, validity, and cross-process usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->