### PR TITLE
Document the x86 vector backend's safety contract

### DIFF
--- a/moirai-utils/src/simd/arch/x86.rs
+++ b/moirai-utils/src/simd/arch/x86.rs
@@ -1,4 +1,49 @@
-//! x86 native vector backend.
+//! x86 native vector backend (AVX2).
+//!
+//! Every kernel here is an `unsafe fn` carrying the same three preconditions, so
+//! they are stated once and referenced by each `# Safety` section rather than
+//! restated eleven times. All of them are discharged by the dispatcher in
+//! `simd::scalar`, which is the only caller.
+//!
+//! # The shared contract
+//!
+//! 1. **AVX2 is available on this CPU.** These functions are compiled with
+//!    `#[target_feature(enable = "avx2")]`, so executing one on a CPU without
+//!    AVX2 is undefined behavior (in practice `SIGILL`). The dispatcher probes
+//!    `has_avx2_support` — `is_x86_feature_detected!("avx2")` — before every
+//!    call and otherwise takes the scalar path. Note that AVX2 transitively
+//!    enables SSE4.1 in the compiler's feature hierarchy, which is what makes
+//!    the `_mm_dp_ps` in `matrix_mul_square` legitimate under this attribute.
+//! 2. **The slices have equal length.** Each kernel derives its trip count from
+//!    one slice and indexes all of them with it, so a shorter operand would read
+//!    or write out of bounds. Call sites pass `&x[..chunk_len]` for one shared
+//!    `chunk_len`; slicing panics rather than producing a short slice, so the
+//!    equality is enforced at the boundary and cannot reach these bodies.
+//! 3. **The length is a whole number of blocks** (`len % LANES == 0`). Callers
+//!    compute `chunk_len` as `(len / LANES) * LANES` and hand the remainder to
+//!    the scalar tail, so partial blocks never arrive here.
+//!
+//! The `debug_assert_eq!`s in each body restate 2 and 3 so a violated contract
+//! surfaces as a dev-build panic instead of release-build memory corruption.
+//!
+//! `matrix_mul_square` additionally requires all three slices to be exactly 16
+//! elements; it is the one kernel using unchecked indexing, and the dispatcher
+//! runs `scalar_matrix_shape` — real `assert_eq!`s, not debug-only — immediately
+//! before calling it.
+//!
+//! # Block width
+//!
+//! `LANES` is 8 for both real widths, which is what lets one prefix/tail
+//! contract serve both: single precision fills one 8-lane `__m256` per block,
+//! and double precision fills two 4-lane `__m256d` registers per block.
+//!
+//! # Reduction order
+//!
+//! The reductions accumulate into vector lanes and fold them at the end, so they
+//! sum in a different order than a sequential loop. Floating-point addition is
+//! not associative: results agree with the scalar path to within a derived
+//! roundoff bound, not bitwise, except where every partial sum is exactly
+//! representable. Differential tests bound the difference accordingly.
 
 use core::arch::x86_64::*;
 
@@ -6,6 +51,11 @@ use core::arch::x86_64::*;
 // path uses two four-lane registers per block to keep one prefix/tail contract.
 pub(crate) const LANES: usize = 8;
 
+/// Element-wise `left + right` into `result`.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available, all three slices of equal
+/// length, and that length a multiple of `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn add(left: &[f32], right: &[f32], result: &mut [f32]) {
     debug_assert_eq!(left.len(), right.len());
@@ -14,6 +64,9 @@ pub(crate) unsafe fn add(left: &[f32], right: &[f32], result: &mut [f32]) {
 
     for lane in 0..left.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: `offset + LANES <= len` on every iteration, and all three
+        // slices are `len` long, so each 8-lane access stays in bounds. The
+        // loads and store are unaligned forms, so no alignment is required.
         unsafe {
             let left_values = _mm256_loadu_ps(left.as_ptr().add(offset));
             let right_values = _mm256_loadu_ps(right.as_ptr().add(offset));
@@ -23,6 +76,11 @@ pub(crate) unsafe fn add(left: &[f32], right: &[f32], result: &mut [f32]) {
     }
 }
 
+/// Element-wise `left * right` into `result`.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available, all three slices of equal
+/// length, and that length a multiple of `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn mul(left: &[f32], right: &[f32], result: &mut [f32]) {
     debug_assert_eq!(left.len(), right.len());
@@ -31,6 +89,7 @@ pub(crate) unsafe fn mul(left: &[f32], right: &[f32], result: &mut [f32]) {
 
     for lane in 0..left.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: as `add` — every 8-lane access lies within the common length.
         unsafe {
             let left_values = _mm256_loadu_ps(left.as_ptr().add(offset));
             let right_values = _mm256_loadu_ps(right.as_ptr().add(offset));
@@ -40,6 +99,14 @@ pub(crate) unsafe fn mul(left: &[f32], right: &[f32], result: &mut [f32]) {
     }
 }
 
+/// Dot product of `left` and `right`.
+///
+/// Accumulates per lane and folds at the end, so the summation order differs
+/// from a sequential loop (see the module's reduction-order note).
+///
+/// # Safety
+/// The module's shared contract: AVX2 available, both slices of equal length,
+/// and that length a multiple of `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn dot(left: &[f32], right: &[f32]) -> f32 {
     debug_assert_eq!(left.len(), right.len());
@@ -48,6 +115,8 @@ pub(crate) unsafe fn dot(left: &[f32], right: &[f32]) -> f32 {
     let mut total = _mm256_setzero_ps();
     for lane in 0..left.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: both slices are the same length and every 8-lane load lies
+        // within it.
         unsafe {
             let left_values = _mm256_loadu_ps(left.as_ptr().add(offset));
             let right_values = _mm256_loadu_ps(right.as_ptr().add(offset));
@@ -58,6 +127,14 @@ pub(crate) unsafe fn dot(left: &[f32], right: &[f32]) -> f32 {
     horizontal_sum(total)
 }
 
+/// Sum of `data`.
+///
+/// Accumulates per lane and folds at the end (see the module's reduction-order
+/// note).
+///
+/// # Safety
+/// The module's shared contract: AVX2 available and `data.len()` a multiple of
+/// `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sum(data: &[f32]) -> f32 {
     debug_assert_eq!(data.len() % LANES, 0);
@@ -65,6 +142,7 @@ pub(crate) unsafe fn sum(data: &[f32]) -> f32 {
     let mut total = _mm256_setzero_ps();
     for lane in 0..data.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: every 8-lane load lies within `data`.
         unsafe {
             let values = _mm256_loadu_ps(data.as_ptr().add(offset));
             total = _mm256_add_ps(total, values);
@@ -74,6 +152,11 @@ pub(crate) unsafe fn sum(data: &[f32]) -> f32 {
     horizontal_sum(total)
 }
 
+/// Sum of `(value - mean)^2` over `data`, the variance numerator.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available and `data.len()` a multiple of
+/// `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn squared_diff_sum(data: &[f32], mean: f32) -> f32 {
     debug_assert_eq!(data.len() % LANES, 0);
@@ -83,6 +166,7 @@ pub(crate) unsafe fn squared_diff_sum(data: &[f32], mean: f32) -> f32 {
 
     for lane in 0..data.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: every 8-lane load lies within `data`.
         unsafe {
             let values = _mm256_loadu_ps(data.as_ptr().add(offset));
             let diff = _mm256_sub_ps(values, mean_values);
@@ -93,6 +177,12 @@ pub(crate) unsafe fn squared_diff_sum(data: &[f32], mean: f32) -> f32 {
     horizontal_sum(total)
 }
 
+/// Row-major 4x4 matrix product, `result = left * right`.
+///
+/// # Safety
+/// AVX2 must be available, and all three slices must be exactly 16 elements —
+/// this kernel indexes them unchecked. The dispatcher enforces the length with
+/// `scalar_matrix_shape`, whose `assert_eq!`s run in release too.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn matrix_mul_square(left: &[f32], right: &[f32], result: &mut [f32]) {
     debug_assert_eq!(left.len(), 16);
@@ -100,6 +190,11 @@ pub(crate) unsafe fn matrix_mul_square(left: &[f32], right: &[f32], result: &mut
     debug_assert_eq!(result.len(), 16);
 
     for row in 0..4 {
+        // SAFETY: with all three slices 16 elements long, every index below is
+        // in bounds: the row load covers `row * 4 .. row * 4 + 4` for `row < 4`,
+        // the gathered column indices are `col`, `4 + col`, `8 + col`,
+        // `12 + col` for `col < 4`, and the store index `row * 4 + col` is at
+        // most 15. `_mm_dp_ps` is SSE4.1, which `avx2` transitively enables.
         unsafe {
             let left_row = _mm_loadu_ps(left.as_ptr().add(row * 4));
             for col in 0..4 {
@@ -116,6 +211,11 @@ pub(crate) unsafe fn matrix_mul_square(left: &[f32], right: &[f32], result: &mut
     }
 }
 
+/// Fold eight lanes to their scalar sum.
+///
+/// Safe despite `target_feature`: it takes an already-formed vector and touches
+/// no memory, so the only requirement is AVX2, which the compiler enforces by
+/// permitting calls solely from functions that enable the same feature.
 #[inline]
 #[target_feature(enable = "avx2")]
 fn horizontal_sum(values: __m256) -> f32 {
@@ -128,6 +228,11 @@ fn horizontal_sum(values: __m256) -> f32 {
     _mm_cvtss_f32(total)
 }
 
+/// Element-wise `left + right` into `result`, double precision.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available, all three slices of equal
+/// length, and that length a multiple of `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn add_wide(left: &[f64], right: &[f64], result: &mut [f64]) {
     debug_assert_eq!(left.len(), right.len());
@@ -136,6 +241,9 @@ pub(crate) unsafe fn add_wide(left: &[f64], right: &[f64], result: &mut [f64]) {
 
     for lane in 0..left.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: a block spans `offset .. offset + LANES` and is covered by two
+        // 4-lane accesses at `offset` and `offset + 4`, so the whole block lies
+        // within the common length.
         unsafe {
             let left_v0 = _mm256_loadu_pd(left.as_ptr().add(offset));
             let left_v1 = _mm256_loadu_pd(left.as_ptr().add(offset + 4));
@@ -149,6 +257,11 @@ pub(crate) unsafe fn add_wide(left: &[f64], right: &[f64], result: &mut [f64]) {
     }
 }
 
+/// Element-wise `left * right` into `result`, double precision.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available, all three slices of equal
+/// length, and that length a multiple of `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn mul_wide(left: &[f64], right: &[f64], result: &mut [f64]) {
     debug_assert_eq!(left.len(), right.len());
@@ -157,6 +270,7 @@ pub(crate) unsafe fn mul_wide(left: &[f64], right: &[f64], result: &mut [f64]) {
 
     for lane in 0..left.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: as `add_wide` — the two 4-lane accesses cover the block.
         unsafe {
             let left_v0 = _mm256_loadu_pd(left.as_ptr().add(offset));
             let left_v1 = _mm256_loadu_pd(left.as_ptr().add(offset + 4));
@@ -170,6 +284,11 @@ pub(crate) unsafe fn mul_wide(left: &[f64], right: &[f64], result: &mut [f64]) {
     }
 }
 
+/// Dot product of `left` and `right`, double precision.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available, both slices of equal length,
+/// and that length a multiple of `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn dot_wide(left: &[f64], right: &[f64]) -> f64 {
     debug_assert_eq!(left.len(), right.len());
@@ -179,6 +298,7 @@ pub(crate) unsafe fn dot_wide(left: &[f64], right: &[f64]) -> f64 {
     let mut total_v1 = _mm256_setzero_pd();
     for lane in 0..left.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: as `add_wide` — the two 4-lane loads cover the block.
         unsafe {
             let left_v0 = _mm256_loadu_pd(left.as_ptr().add(offset));
             let left_v1 = _mm256_loadu_pd(left.as_ptr().add(offset + 4));
@@ -192,6 +312,11 @@ pub(crate) unsafe fn dot_wide(left: &[f64], right: &[f64]) -> f64 {
     horizontal_sum_wide(_mm256_add_pd(total_v0, total_v1))
 }
 
+/// Sum of `data`, double precision.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available and `data.len()` a multiple of
+/// `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn sum_wide(data: &[f64]) -> f64 {
     debug_assert_eq!(data.len() % LANES, 0);
@@ -200,6 +325,7 @@ pub(crate) unsafe fn sum_wide(data: &[f64]) -> f64 {
     let mut total_v1 = _mm256_setzero_pd();
     for lane in 0..data.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: as `add_wide` — the two 4-lane loads cover the block.
         unsafe {
             let values_v0 = _mm256_loadu_pd(data.as_ptr().add(offset));
             let values_v1 = _mm256_loadu_pd(data.as_ptr().add(offset + 4));
@@ -211,6 +337,11 @@ pub(crate) unsafe fn sum_wide(data: &[f64]) -> f64 {
     horizontal_sum_wide(_mm256_add_pd(total_v0, total_v1))
 }
 
+/// Sum of `(value - mean)^2` over `data`, double precision.
+///
+/// # Safety
+/// The module's shared contract: AVX2 available and `data.len()` a multiple of
+/// `LANES`.
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn squared_diff_sum_wide(data: &[f64], mean: f64) -> f64 {
     debug_assert_eq!(data.len() % LANES, 0);
@@ -221,6 +352,7 @@ pub(crate) unsafe fn squared_diff_sum_wide(data: &[f64], mean: f64) -> f64 {
 
     for lane in 0..data.len() / LANES {
         let offset = lane * LANES;
+        // SAFETY: as `add_wide` — the two 4-lane loads cover the block.
         unsafe {
             let values_v0 = _mm256_loadu_pd(data.as_ptr().add(offset));
             let values_v1 = _mm256_loadu_pd(data.as_ptr().add(offset + 4));
@@ -234,6 +366,8 @@ pub(crate) unsafe fn squared_diff_sum_wide(data: &[f64], mean: f64) -> f64 {
     horizontal_sum_wide(_mm256_add_pd(total_v0, total_v1))
 }
 
+/// Fold four lanes to their scalar sum. Safe for the same reason as
+/// [`horizontal_sum`].
 #[inline]
 #[target_feature(enable = "avx2")]
 fn horizontal_sum_wide(values: __m256d) -> f64 {

--- a/moirai-utils/src/simd/arch/x86.rs
+++ b/moirai-utils/src/simd/arch/x86.rs
@@ -213,9 +213,11 @@ pub(crate) unsafe fn matrix_mul_square(left: &[f32], right: &[f32], result: &mut
 
 /// Fold eight lanes to their scalar sum.
 ///
-/// Safe despite `target_feature`: it takes an already-formed vector and touches
-/// no memory, so the only requirement is AVX2, which the compiler enforces by
-/// permitting calls solely from functions that enable the same feature.
+/// Safe despite `target_feature` because it takes an already-formed vector and
+/// touches no memory, so it has no precondition beyond AVX2 itself. That one
+/// still binds: a caller that already enables `avx2` — every caller in this
+/// module — may call it directly, and any other caller would have to discharge
+/// the requirement itself inside an `unsafe` block.
 #[inline]
 #[target_feature(enable = "avx2")]
 fn horizontal_sum(values: __m256) -> f32 {
@@ -366,8 +368,8 @@ pub(crate) unsafe fn squared_diff_sum_wide(data: &[f64], mean: f64) -> f64 {
     horizontal_sum_wide(_mm256_add_pd(total_v0, total_v1))
 }
 
-/// Fold four lanes to their scalar sum. Safe for the same reason as
-/// [`horizontal_sum`].
+/// Fold four lanes to their scalar sum. Safe on the same terms as
+/// `horizontal_sum`, and carrying the same AVX2 requirement.
 #[inline]
 #[target_feature(enable = "avx2")]
 fn horizontal_sum_wide(values: __m256d) -> f64 {

--- a/moirai-utils/src/simd/tests.rs
+++ b/moirai-utils/src/simd/tests.rs
@@ -142,9 +142,18 @@ fn unaligned_lengths_preserve_values() {
         let expected_dot: f32 = left.iter().zip(right.iter()).map(|(x, y)| x * y).sum();
         assert_f32_roundoff(result_dot, expected_dot, len, 2, "dot mismatch");
 
+        // Roundoff-bounded, not exact: the vector path accumulates into lanes and
+        // folds them at the end, so it adds in a different order than this
+        // sequential reference, and floating-point addition is not associative.
+        // Bitwise equality holds here only because `left` is small integers whose
+        // partial sums are all exactly representable — it is not a property of
+        // the operation, and asserting it would break the moment the fixture
+        // changed. One addition per element, as against `dot`'s multiply-add.
+        // (`add`/`mul` above stay exact: they are element-wise, so the vector and
+        // scalar paths perform identical operations in identical order.)
         let result_sum = sum(&left);
         let expected_sum: f32 = left.iter().copied().sum();
-        assert_eq!(result_sum, expected_sum, "sum mismatch at len {len}");
+        assert_f32_roundoff(result_sum, expected_sum, len, 1, "sum mismatch");
 
         let result_var = variance(&left);
         let mean_val = mean(&left);


### PR DESCRIPTION
Eighth increment of the moirai unsafe audit — `moirai-utils/src/simd/arch/x86.rs`, the AVX2 vector backend. **22 unsafe sites, 0 safety comments, and no `# Safety` section on any of the eleven `unsafe fn`s** — the thinnest documentation ratio of the series so far.

## Audit result: sound

The preconditions existed only as `debug_assert`s, which vanish in release — precisely where violating them would corrupt memory rather than panic. But all three are genuinely discharged by the dispatcher in `simd::scalar`, the only caller:

| Precondition | Enforced by |
|---|---|
| AVX2 available | `has_avx2_support()` → `is_x86_feature_detected!("avx2")`, checked before every dispatch; otherwise the scalar path runs |
| Slices of equal length | Call sites pass `&x[..chunk_len]` for one shared `chunk_len`. **Slicing panics rather than producing a short operand**, so a mismatch cannot reach these bodies even in release |
| Length a multiple of `LANES` | `chunk_len = (len / LANES) * LANES`, remainder handed to the scalar tail |

`matrix_mul_square` is the one kernel using unchecked indexing; it is preceded by `scalar_matrix_shape`, whose `assert_eq!`s are **not** debug-only, so all three slices are proven to be exactly 16 elements. Its `_mm_dp_ps` is SSE4.1, which `avx2` transitively enables in the compiler's feature hierarchy — so the attribute covers it.

I verified the arithmetic rather than assuming it: both horizontal folds reduce all lanes correctly (`_mm_shuffle_ps(.., 0x4E)` then `0x01` sums all four f32 lanes into lane 0; the f64 fold likewise), and `matrix_mul_square`'s `_mm_set_ps` reverse-argument order does yield column `col` of a row-major matrix, so the product is `sum_k left[row][k] * right[k][col]`.

No defect found in the kernels.

## Changes

**Documentation.** The three preconditions are stated once in a module doc and each function's `# Safety` section points at it, rather than restating them eleven times; every unsafe block gets a `SAFETY` comment covering why its accesses are in bounds. Also records two things that were previously implicit: why the horizontal folds are allowed to be *safe* functions under `#[target_feature]` (they take an already-formed vector and touch no memory, and the compiler only permits calls from functions enabling the same feature), and that the reductions are roundoff-equal to the scalar path rather than bitwise-equal.

**One real issue, in the tests.** `unaligned_lengths_preserve_values` compared the vector `sum` against a sequential reference with `assert_eq!`:

```rust
let result_sum = sum(&left);
let expected_sum: f32 = left.iter().copied().sum();
assert_eq!(result_sum, expected_sum, "sum mismatch at len {len}");
```

The vector path accumulates into eight lanes and folds at the end — a different addition order — and floating-point addition is not associative, so bitwise equality is not a property of the operation. It passes only because the fixture is `0..len` as `f32`, small integers whose partial sums are all exactly representable. Change the fixture to anything fractional and it breaks, at which point the tempting repair is an ad hoc tolerance.

This is the case the repo's own numerical discipline calls out — bitwise equality is asserted only where evaluation order provably matches, which here it provably does not. The file already applies a derived-roundoff bound to its other two reductions (`dot`, `variance`); `sum` now uses the same, with one addition per element against `dot`'s multiply-add. The bound stays tight enough to catch a real defect: dropping or double-counting a lane moves the result by far more than `len * EPSILON`.

`add` and `mul` keep exact equality, which is correct — being element-wise, the vector and scalar paths perform identical operations in identical order.

## Verification

Run on an AVX2 host (Intel Core Ultra 9 285K), so `has_avx2_support()` is true and these kernels actually executed rather than falling back to scalar — `unaligned_vector_prefix_records_vector_dispatch_when_available` passing confirms the vector path was dispatched.

- `cargo fmt -p moirai-utils -- --check` ✓
- `cargo clippy -p moirai-utils --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-utils` — 30/30 ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-utils` ✓

Audit progress: eight moirai files — five sound (deque, parallel ops, async_state, result_slot, this one), three with defects found and fixed (async task re-entry #92, shared-memory sizing #93, errno discipline #94).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR documents the safety contracts for the AVX2 vector backend in the x86 SIMD module as part of an ongoing unsafe code audit. The backend previously had 22 unsafe sites and 11 unsafe functions without any safety documentation. The PR adds comprehensive module-level documentation explaining the three shared preconditions (AVX2 availability, equal-length slices, and length divisible by LANES), adds `# Safety` sections to all unsafe functions, and provides SAFETY comments for every unsafe block explaining why memory accesses are valid. Additionally, it fixes a subtle testing bug where `sum` was incorrectly using exact equality (`assert_eq!`) instead of a roundoff-bounded comparison, which would fail with non-integer inputs due to floating-point non-associativity from different accumulation orders between vector and scalar paths.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-utils/src/simd/arch/x86.rs` |
| 2 | `moirai-utils/src/simd/tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded safety documentation for x86 AVX2 SIMD operations, including hardware requirements, input constraints, memory access guarantees, and floating-point reduction behavior.
  * Added clearer explanations for vectorized horizontal-sum operations.

* **Tests**
  * Updated floating-point sum validation to allow expected rounding differences caused by vectorized accumulation order.
  * Added comments clarifying why exact equality is not reliable for these calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->