### PR TITLE
fix(core): Reserve shared-memory backing store

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Test native binding crate
         run: cargo nextest run --locked -p moirai-python --all-features
 
-      - name: Test shared-memory size boundary
+      - name: Test shared-memory mapping invariants
         run: cargo nextest run --locked -p moirai-core --no-default-features --features std
 
       - name: Test binding documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surplus pages unbacked, so `as_slice` handed out bytes that raise `SIGBUS` on
   read; `open` now checks the segment with `fstat` first. Windows already
   refused the oversized view in `MapViewOfFile`.
+- Reserve the backing store of a Linux `SharedMemory::create` segment with
+  `posix_fallocate`. `ftruncate` only sets the length of a tmpfs object and
+  leaves its pages sparse, so a correctly sized segment still raised `SIGBUS`
+  through `as_slice`/`as_mut_slice` when the store could not produce a page on
+  first touch; the shortage now surfaces as an error at creation, and the failed
+  segment is unlinked rather than left for a later `open` to map. Unix targets
+  without `posix_fallocate`, macOS among them, are unchanged.
 - Test the async task completion flag under the future lock rather than before
   acquiring it, so a second thread polling the same executor cannot pass the
   check, wait for the lock, and then poll a future that completed meanwhile —

--- a/moirai-core/src/ipc/memory.rs
+++ b/moirai-core/src/ipc/memory.rs
@@ -5,28 +5,47 @@
 //! [`SharedQueue`](super::SharedQueue); the two contracts below are what make
 //! its safe API sound.
 //!
-//! # The mapping must cover `size`
+//! # Every mapped byte must be backed
 //!
-//! `as_slice`/`as_mut_slice` build a slice of exactly `size` bytes, so the
-//! mapping has to be backed for all of them. The two platforms differ in who
-//! enforces that, and the difference is why `open` is written the way it is:
+//! `as_slice`/`as_mut_slice` build a slice of exactly `size` bytes, so all of
+//! them have to be backed. Two independent things can leave the mapping short,
+//! and either one raises `SIGBUS` on first touch inside those safe accessors.
+//!
+//! ## The object must be at least `size` bytes
+//!
+//! The two platforms differ in who enforces that, and the difference is why
+//! `open` is written the way it is:
 //!
 //! - **Windows** enforces it. `MapViewOfFile` requires the requested view to lie
 //!   within the mapping object, and fails otherwise, so an oversized `open` is
 //!   rejected by the OS.
 //! - **POSIX does not.** `mmap` accepts a length running past the end of the
-//!   object; the pages beyond it simply are not backed, and touching them raises
-//!   `SIGBUS`. `open` therefore `fstat`s the descriptor and rejects a segment
-//!   smaller than `size` itself — without that check a caller could open an
-//!   existing segment under a too-large `size` and get a slice that faults on
-//!   read. `create` needs no such check because its `ftruncate` sets the object
-//!   to exactly `size`.
+//!   object; the pages beyond it simply are not backed. `open` therefore
+//!   `fstat`s the descriptor and rejects a segment smaller than `size` itself —
+//!   without that check a caller could open an existing segment under a
+//!   too-large `size` and get a slice that faults on read. `create` needs no
+//!   such check because its `ftruncate` sets the object to exactly `size`.
 //!
 //! The POSIX check reads the size from the descriptor it goes on to map, so it
 //! cannot be defeated by re-resolving the name. It does not cover a process that
 //! *shrinks* the object with `ftruncate` after the check — an act that already
 //! invalidates every existing mapping of that segment, and which POSIX gives no
 //! way to exclude.
+//!
+//! ## The object's pages must exist
+//!
+//! A correctly sized object is not automatically a backed one. Linux puts POSIX
+//! shared memory on tmpfs, where `ftruncate` sets the length and nothing else:
+//! the pages stay sparse and are allocated on first touch. A segment can pass
+//! every size check above and still fault, when tmpfs — or the RAM and swap
+//! behind it — cannot produce a page at the moment one is written.
+//!
+//! `create` closes that by asking for the store up front with `posix_fallocate`,
+//! so a segment too large to back is refused at creation with the kernel's
+//! `ENOSPC` rather than killing whichever process later writes it. That is a
+//! Linux guarantee rather than a POSIX one; `reserve_backing_store` documents
+//! what the other Unix targets do and do not get. `open` needs no counterpart,
+//! since it maps an object whose creator already reserved it.
 //!
 //! # Cross-process aliasing is the caller's contract
 //!
@@ -113,6 +132,92 @@ fn unix_mapping_length(size: usize) -> Result<libc::off_t, IpcError> {
     libc::off_t::try_from(size).map_err(|_| IpcError::InvalidArgument)
 }
 
+/// What the kernel answered when asked to reserve a segment's backing store.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Reservation {
+    /// The store is committed: every page of the segment exists.
+    Reserved,
+    /// This object cannot be preallocated at all, so it keeps the sparse
+    /// backing `ftruncate` gave it.
+    Unsupported,
+    /// A signal arrived first; the request has to be reissued.
+    Interrupted,
+    /// The store cannot be had, under the reported `errno`.
+    Failed(i32),
+}
+
+/// Classify what `posix_fallocate` returned.
+///
+/// Unlike the `shm_open`/`ftruncate`/`mmap` calls around it, `posix_fallocate`
+/// reports through its return value and leaves `errno` untouched, so the code
+/// arrives here directly instead of through `last_os_error`.
+///
+/// The distinction that matters is between a kernel that *will not preallocate
+/// here* and one that *cannot find the store*. `create` has already rejected a
+/// non-positive length, so `EINVAL` can only mean this object refuses the
+/// operation, as `EOPNOTSUPP` and `ENOSYS` do on a filesystem without fallocate
+/// — tmpfs before Linux 3.5, say. None of the three says anything about free
+/// space, and failing creation on them would break segments that work today, so
+/// they leave the mapping as sparse as it was before this call existed. Every
+/// other code — `ENOSPC` and `EFBIG` above all — is the shortage the call exists
+/// to surface.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(super) const fn classify_reservation(code: i32) -> Reservation {
+    match code {
+        0 => Reservation::Reserved,
+        libc::EINTR => Reservation::Interrupted,
+        libc::EOPNOTSUPP | libc::ENOSYS | libc::EINVAL => Reservation::Unsupported,
+        other => Reservation::Failed(other),
+    }
+}
+
+/// Reserve a whole segment's backing store, so its pages exist before anyone
+/// maps them.
+///
+/// `ftruncate` sets the object's length and nothing more. On tmpfs the pages
+/// behind that length stay sparse, so the first write to one can fail for want
+/// of memory — as `SIGBUS`, inside a safe accessor, in whichever process
+/// happened to touch it. Asking for the pages here turns that fault into an
+/// ordinary error at creation.
+///
+/// Returns `Ok` when the store is committed, and equally when the kernel
+/// declines to preallocate at all: the segment is still exactly `size` bytes, so
+/// such a caller keeps the behavior it had before, and only a reported shortage
+/// is an error. See `classify_reservation` for the split.
+///
+/// Unix targets outside the Linux family have no counterpart here.
+/// `posix_fallocate` is absent on macOS, and this crate cannot claim tmpfs
+/// semantics for platforms whose shared memory is not tmpfs, so their segments
+/// keep the sparse mapping and the `SIGBUS` window that comes with it.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn reserve_backing_store(fd: RawFd, length: libc::off_t) -> Result<(), IpcError> {
+    loop {
+        // SAFETY: `posix_fallocate` takes `fd` as a descriptor number and two
+        // integers, and answers through its return value — no pointer crosses
+        // the call, so no argument reachable here can make it unsound. A
+        // descriptor that is not open comes back as `EBADF`.
+        let code = unsafe { libc::posix_fallocate(fd, 0, length) };
+
+        match classify_reservation(code) {
+            Reservation::Reserved | Reservation::Unsupported => return Ok(()),
+            Reservation::Interrupted => {}
+            Reservation::Failed(code) => return Err(IpcError::SystemError(code)),
+        }
+    }
+}
+
+/// Preallocation is unavailable on this target, so a segment keeps the sparse
+/// backing `ftruncate` gave it. See the Linux definition for what that costs.
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "matches the fallible Linux signature so `create` stays platform-uniform"
+)]
+fn reserve_backing_store(_fd: RawFd, _length: libc::off_t) -> Result<(), IpcError> {
+    Ok(())
+}
+
 // SAFETY: the mapping is process-wide, not thread-owned — `ptr` stays valid on
 // any thread for the lifetime of this handle, and neither the descriptor nor the
 // handle is thread-affine. `Send` therefore moves a still-valid mapping.
@@ -126,7 +231,13 @@ unsafe impl Send for SharedMemory {}
 unsafe impl Sync for SharedMemory {}
 
 impl SharedMemory {
-    /// Create a new shared memory segment
+    /// Create a new shared memory segment.
+    ///
+    /// Sizes the object with `ftruncate` and then reserves its backing store, so
+    /// a segment larger than the store can hold fails here — as the kernel's
+    /// `ENOSPC` — instead of raising `SIGBUS` in whichever process first writes
+    /// an unbacked page. `reserve_backing_store` covers the Unix targets that
+    /// cannot make that reservation.
     #[cfg(unix)]
     pub fn create(name: &str, size: usize) -> Result<Self, IpcError> {
         use std::ffi::CString;
@@ -149,6 +260,17 @@ impl SharedMemory {
             if libc::ftruncate(fd, mapping_length) < 0 {
                 libc::close(fd);
                 return Err(last_os_error());
+            }
+
+            if let Err(error) = reserve_backing_store(fd, mapping_length) {
+                // Unlike the paths around it, this one has to take the name down
+                // with the descriptor. What it would otherwise leave behind is
+                // precisely the trap the reservation exists to remove: an object
+                // of exactly `size` bytes, which `open`'s `fstat` check waves
+                // through, over pages the store was just proven unable to hold.
+                libc::close(fd);
+                libc::shm_unlink(c_name.as_ptr());
+                return Err(error);
             }
 
             let ptr = libc::mmap(
@@ -324,11 +446,12 @@ impl SharedMemory {
     /// (see the module docs); use [`SharedQueue`](super::SharedQueue) when
     /// another process is an active writer.
     pub fn as_slice(&self) -> &[u8] {
-        // SAFETY: `ptr` is a live mapping of `size` bytes — `create` sized the
-        // object with `ftruncate` and `open` rejected a segment smaller than
-        // `size` — so every byte is backed and readable, and `u8` needs no
-        // alignment beyond the page-aligned base. Absence of a concurrent
-        // cross-process writer is the caller's contract.
+        // SAFETY: `ptr` is a live mapping of `size` bytes — `create` sizes the
+        // object with `ftruncate` and reserves its backing store, `open` rejects
+        // a segment smaller than `size` — so every byte is readable, and `u8`
+        // needs no alignment beyond the page-aligned base. The residual backing
+        // hazard on Unix targets that cannot preallocate, and the absence of a
+        // concurrent cross-process writer, are the module docs' two contracts.
         unsafe { slice::from_raw_parts(self.ptr, self.size) }
     }
 

--- a/moirai-core/src/ipc/tests.rs
+++ b/moirai-core/src/ipc/tests.rs
@@ -81,6 +81,93 @@ fn segment_larger_than_off_t_is_rejected_before_creation() {
 }
 
 #[test]
+fn a_multi_page_segment_reads_back_across_its_whole_length() {
+    // Sizing a segment is not backing it: on tmpfs `ftruncate` leaves the pages
+    // sparse, so `create` reserves the store before handing out a mapping.
+    // Writing every page is what would fault on a host that could not satisfy
+    // that reservation, and reading it back is what fails if the new call
+    // started refusing segments the store can perfectly well hold.
+    let name = "/moirai_test_backed_pages";
+    let size = 256 * 1024;
+    // 251 is the largest prime below 256, so the pattern's period is coprime
+    // with the page size: no two pages begin with the same byte, and a page
+    // that silently read back as another's contents would not match.
+    let marker = |index: usize| {
+        u8::try_from(index % 251).expect("invariant: a remainder mod 251 fits in u8")
+    };
+
+    let mut segment = SharedMemory::create(name, size).expect("create must succeed");
+    for (index, byte) in segment.as_mut_slice().iter_mut().enumerate() {
+        *byte = marker(index);
+    }
+
+    let written = segment.as_slice();
+    assert_eq!(written.len(), size);
+    assert_eq!(
+        written
+            .iter()
+            .enumerate()
+            .position(|(index, &byte)| byte != marker(index)),
+        None,
+        "every byte of a created segment must read back what was written to it"
+    );
+}
+
+/// The reservation `create` performs is classified from `posix_fallocate`'s
+/// return value, and that classification is the part with no deterministic
+/// end-to-end test: reaching the `ENOSPC` arm for real means exhausting the
+/// host's tmpfs, which no test may do to the machine running it. Requesting an
+/// absurd length does not substitute — it returns `ENOSPC` early only when
+/// `/dev/shm` carries a size limit, and on a mount without one the kernel goes
+/// away and tries to allocate it. What is deterministic is the decision itself,
+/// over one representative code per outcome.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod reservation_classification {
+    use super::super::memory::{classify_reservation, Reservation};
+
+    #[test]
+    fn a_committed_reservation_is_the_only_success() {
+        assert_eq!(classify_reservation(0), Reservation::Reserved);
+    }
+
+    #[test]
+    fn a_shortage_fails_creation_instead_of_deferring_a_fault() {
+        // The reason the call exists: a segment the store cannot hold has to be
+        // refused here, not become a `SIGBUS` in whichever process writes it.
+        for code in [libc::ENOSPC, libc::EFBIG] {
+            assert_eq!(classify_reservation(code), Reservation::Failed(code));
+        }
+    }
+
+    #[test]
+    fn a_kernel_that_will_not_preallocate_leaves_creation_alone() {
+        // tmpfs before Linux 3.5, or any object refusing fallocate. None of
+        // these reports a shortage, and failing on them would break segments
+        // that create fine today. `create` rejects a non-positive length before
+        // reaching the call, so `EINVAL` cannot be our own argument error.
+        for code in [libc::EOPNOTSUPP, libc::ENOSYS, libc::EINVAL] {
+            assert_eq!(classify_reservation(code), Reservation::Unsupported);
+        }
+    }
+
+    #[test]
+    fn an_interrupted_reservation_is_reissued_rather_than_accepted() {
+        // Reading `EINTR` as completion would leave behind exactly the sparse
+        // segment the reservation was meant to eliminate.
+        assert_eq!(classify_reservation(libc::EINTR), Reservation::Interrupted);
+    }
+
+    #[test]
+    fn an_unrecognized_code_is_carried_through_as_a_failure() {
+        // The default arm must not quietly widen into "unsupported": an `EIO` or
+        // `EBADF` is a real failure and has to reach the caller intact.
+        for code in [libc::EIO, libc::EBADF, libc::EPERM] {
+            assert_eq!(classify_reservation(code), Reservation::Failed(code));
+        }
+    }
+}
+
+#[test]
 fn test_shared_queue() {
     let name = "/moirai_test_queue";
     let capacity = 10;


### PR DESCRIPTION
## The defect

Linux places POSIX shared memory on tmpfs, where `ftruncate` sets only the object's *length*. The pages behind that length stay sparse and are allocated on first touch, so a segment can be exactly `size` bytes and still fault: `as_slice`/`as_mut_slice` hand out bytes over pages tmpfs (or the RAM and swap behind it) cannot produce, and the resulting `SIGBUS` lands in whichever process wrote them — reachable entirely through the safe accessors.

This is orthogonal to the sizing defect fixed in #93. That one closed "the mapping runs past the end of the object"; this one is "the object is correctly sized but has no store behind it". It was raised by CodeRabbit on #93 and deferred rather than widening that PR.

## The fix

`create` reserves the store with `posix_fallocate` after `ftruncate`, so a segment too large to back fails at creation with the kernel's `ENOSPC` instead of killing a process later.

Three things are worth review attention:

**`posix_fallocate` reports through its return value**, not `errno` — unlike the `shm_open`/`ftruncate`/`mmap` calls around it, so it does not go through `last_os_error()`.

**Only a reported shortage fails.** `EOPNOTSUPP`/`ENOSYS`/`EINVAL` mean the kernel will not preallocate on this object at all — tmpfs before Linux 3.5, say. None of them says anything about free space, and failing creation on them would break segments that create fine today, so they leave the mapping exactly as sparse as it was before the call existed. `ENOSPC`, `EFBIG`, and everything unrecognized fail. `EINTR` is reissued: treating it as completion would leave behind precisely the sparse segment being eliminated.

**The failure path unlinks the name.** This is required rather than tidiness — a sized-but-unbacked object left in `/dev/shm` passes `open`'s `fstat` check from #93 and hands out a slice over pages just proven unbackable, which is the trap this PR removes. The neighbouring `mmap` failure path is deliberately left alone: it abandons a segment that *is* fully backed, so it leaks a name rather than planting a fault.

## Portability

Gated to `target_os = "linux"`/`"android"` — where `libc` declares `posix_fallocate`, shared memory *is* tmpfs, and the sparse-page hazard is the one described above. macOS has no `posix_fallocate` at all; those targets keep the previous behaviour and the function documents that it does. Verified by type-checking and linting `aarch64-apple-darwin` (the target CI's macOS wheel job builds), where `moirai-core` produces zero warnings.

## Tests

`reservation_classification` covers the errno decision table — one representative code per outcome, plus the default arm carrying `EIO`/`EBADF`/`EPERM` through as failures rather than quietly widening into "unsupported". `a_multi_page_segment_reads_back_across_its_whole_length` writes and verifies every page of a 256 KiB segment; the marker period (251) is coprime with the page size, so no two pages start with the same byte.

**No deterministic end-to-end `ENOSPC` test is included, deliberately.** Reaching that arm for real means exhausting the host's tmpfs, which a test has no business doing to the machine running it. Requesting an absurd length is not a substitute: `shmem_fallocate` short-circuits to `ENOSPC` only when `/dev/shm` carries a size limit, and on a mount without one the kernel goes away and genuinely attempts the allocation. The classification is what carries the non-obvious logic, and it is deterministic.

## Verification

All on the pinned 1.95.0 toolchain unless noted, cross-compiled from a Windows host:

| Check | Target | Result |
|---|---|---|
| `cargo check -p moirai-core --no-default-features --features std` | `x86_64-unknown-linux-gnu` | clean |
| `cargo clippy … --tests -- -D warnings` | `x86_64-unknown-linux-gnu` | clean |
| `cargo check --tests` / `cargo clippy --tests` (1.97.0) | `aarch64-apple-darwin` | `moirai-core` clean |
| `cargo nextest run --locked -p moirai-core --no-default-features --features std` | host | 73/73 pass |
| `cargo fmt --all -- --check` | — | clean |
| `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` | — | clean |

Runtime coverage of the Linux-gated tests comes from CI's ubuntu job. The host run exercises the platform-neutral tests, including the multi-page segment test, in 0.34s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical memory safety issue in Linux shared memory handling where `ftruncate` only sets the object length on tmpfs but leaves pages sparse, causing `SIGBUS` crashes when accessing unbacked pages through safe APIs. The fix uses `posix_fallocate` to reserve backing store during segment creation, failing early with `ENOSPC` instead of crashing later. The implementation carefully distinguishes between kernels that cannot preallocate (which fall back to sparse allocation) and actual storage shortages (which fail creation). Changes are gated to Linux/Android targets where the issue exists; macOS and other Unix systems maintain their previous behavior since they lack `posix_fallocate`.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `moirai-core/src/ipc/memory.rs` |
| 3 | `moirai-core/src/ipc/tests.rs` |
| 4 | `.github/workflows/python-ci.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->