### PR TITLE
Detect a panicked worker when joining pooled fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surplus pages unbacked, so `as_slice` handed out bytes that raise `SIGBUS` on
   read; `open` now checks the segment with `fstat` first. Windows already
   refused the oversized view in `MapViewOfFile`.
+- Detect a panicked pooled worker when joining `moirai-iter` fan-out. The join
+  discarded the result of each `recv`, so a worker that unwound without sending
+  left the channel disconnected and every later `recv` failed instantly — the
+  join then returned as though all tasks had finished.
+  `ZeroCopyParallelIter::map` consequently called `assume_init` over a slice no
+  worker had written, and `for_each`, `reduce`, and the parallel sorts returned
+  silently partial results. The join now counts completions and panics unless
+  every task reported one.
+- Keep `CacheAlignedChunks` advancing for elements wider than a cache line. The
+  chunk size was `(CACHE_LINE_SIZE / element_size) * (CACHE_CHUNK_SIZE /
+  CACHE_LINE_SIZE)`, whose first term truncates to zero above 64 bytes, leaving
+  the iterator yielding empty slices forever without advancing.
 - Reserve the backing store of a Linux `SharedMemory::create` segment with
   `posix_fallocate`. `ftruncate` only sets the length of a tmpfs object and
   leaves its pages sparse, so a correctly sized segment still raised `SIGBUS`

--- a/moirai-iter/src/base.rs
+++ b/moirai-iter/src/base.rs
@@ -437,17 +437,51 @@ impl PoolJoinGuard {
         Self { rx, count }
     }
 
-    /// Wait for all tasks to finish.
+    /// Wait for all tasks to finish, panicking if any did not.
+    ///
+    /// Each task sends `()` as its last act, so a completion message means that
+    /// task ran to the end. A task that panics instead unwinds without sending
+    /// and drops its sender — the pool's worker loop does not catch unwinds — so
+    /// once every sender is gone `recv` returns `Err` immediately and keeps
+    /// doing so. Counting the successes is what separates "all finished" from
+    /// "the channel disconnected early"; discarding the `Result` makes the two
+    /// indistinguishable and lets a caller proceed as if the work were done.
+    ///
+    /// That distinction is load-bearing: `ZeroCopyParallelIter::map` fills a
+    /// `Vec<MaybeUninit<R>>` from these tasks and calls `assume_init` on every
+    /// element afterwards, so returning normally when a chunk never wrote its
+    /// slice would read uninitialized memory. The other callers lose work rather
+    /// than soundness, but silently returning a partial result is its own defect.
+    ///
+    /// Panicking here surfaces the worker's failure on the caller's thread. The
+    /// `MaybeUninit` buffer is then dropped without dropping its elements — the
+    /// initialized results leak, which is the same trade the executor path makes
+    /// when it reports a failed fan-out.
     pub(crate) fn wait(mut self) {
-        for _ in 0..self.count {
-            let _ = self.rx.recv();
+        let expected = self.count;
+        let mut completed = 0;
+        for _ in 0..expected {
+            if self.rx.recv().is_ok() {
+                completed += 1;
+            }
         }
         self.count = 0; // Prevent waiting again in drop
+        assert_eq!(
+            completed,
+            expected,
+            "invariant: {} of {expected} pooled tasks did not report completion; \
+             a worker panicked and its output was never written",
+            expected - completed
+        );
     }
 }
 
 impl Drop for PoolJoinGuard {
     fn drop(&mut self) {
+        // Best-effort drain only: `drop` may run while a panic is already
+        // unwinding, and panicking again there aborts the process. `wait` is the
+        // checked path; this exists so an early return still blocks until the
+        // workers stop touching the borrowed data.
         for _ in 0..self.count {
             let _ = self.rx.recv();
         }

--- a/moirai-iter/src/base/tests.rs
+++ b/moirai-iter/src/base/tests.rs
@@ -1,6 +1,35 @@
 use super::*;
 
 #[test]
+fn pool_join_guard_accepts_a_full_set_of_completions() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let guard = PoolJoinGuard::new(rx, 3);
+    for _ in 0..3 {
+        tx.send(()).expect("receiver is alive");
+    }
+    drop(tx);
+
+    guard.wait();
+}
+
+#[test]
+#[should_panic(expected = "did not report completion")]
+fn pool_join_guard_rejects_a_missing_completion() {
+    // A worker that panics unwinds without sending and drops its sender, which
+    // is exactly this shape: fewer messages than tasks, then a disconnected
+    // channel. `recv` returns `Err` immediately from then on, so discarding the
+    // result would let `wait` return as though every task had finished — and
+    // `ZeroCopyParallelIter::map` would `assume_init` a slice no worker wrote.
+    let (tx, rx) = std::sync::mpsc::channel();
+    let guard = PoolJoinGuard::new(rx, 3);
+    tx.send(()).expect("receiver is alive");
+    tx.send(()).expect("receiver is alive");
+    drop(tx); // the third task's sender dies with it, as in a panic
+
+    guard.wait();
+}
+
+#[test]
 fn test_tree_reduce() {
     let items = vec![1, 2, 3, 4, 5];
     let result = tree_reduce(items, |a, b| a + b);

--- a/moirai-iter/src/cache.rs
+++ b/moirai-iter/src/cache.rs
@@ -1,22 +1,46 @@
 //! Cache-aware iterator utilities.
+//!
+//! Two kinds of thing live here: sequential views that size themselves to the
+//! cache ([`WindowIterator`], [`CacheAlignedChunks`]), and
+//! [`ZeroCopyParallelIter`], which fans a borrowed slice out across workers
+//! without copying it. The second is where the unsafe code is, and it rests on
+//! the invariants below.
+//!
+//! # Fan-out safety
+//!
+//! Each operation partitions `data` with `slice::chunks(chunk_size)` and gives
+//! worker `i` only chunk `i`, so no two workers touch the same elements. The
+//! borrowed data, the caller's closure, and — for `map` — the output buffer all
+//! cross the thread boundary as raw pointers wrapped in `SendPtr`, because the
+//! borrow checker cannot see the partition. Three things make that sound:
+//!
+//! - **Disjointness.** Chunk `i` starts at `i * chunk_size`, so a worker writing
+//!   `chunk_start + offset` for `offset < chunk.len()` stays inside its own
+//!   range, and the ranges are pairwise disjoint and within `data.len()`.
+//! - **Lifetime.** The pointers refer to locals of the calling frame (`data`'s
+//!   backing store, `func`, `results`). Every path joins its workers before
+//!   returning — the executor call blocks, and the pool path blocks in
+//!   `PoolJoinGuard::wait` — so no worker outlives what it points at.
+//! - **Completion.** `map` writes its output through `MaybeUninit` and calls
+//!   `assume_init` on every element once the workers are done, which is sound
+//!   only if every chunk actually wrote its slice. Both join paths enforce that
+//!   rather than assume it: a failed executor fan-out reaches
+//!   `pool_fallback_permitted`, which retries only a clean `ShuttingDown` and
+//!   panics on a partial run, and the pool path's `wait` panics unless every
+//!   task reported completion. A worker that panics therefore surfaces as a
+//!   panic here instead of an `assume_init` over memory it never wrote.
+//!
+//! # Chunk sizing
+//!
+//! Sizes are derived from `CACHE_CHUNK_SIZE` and the element width, and are
+//! clamped to at least one element. A zero chunk size is not merely slow: it
+//! makes the sequential iterators spin without advancing.
 
 use std::mem;
 
 use crate::base::{PoolJoinGuard, SendPtr};
 /// Default ring buffer capacity (power of 2)
 const DEFAULT_RING_BUFFER_CAPACITY: usize = 1024;
-
-/// Wrapper to make const raw pointers Send
-#[allow(dead_code)]
-struct SendConstPtr<T>(*const T);
-unsafe impl<T> Send for SendConstPtr<T> {}
-
-#[allow(dead_code)]
-impl<T> SendConstPtr<T> {
-    unsafe fn as_ptr(&self) -> *const T {
-        self.0
-    }
-}
 
 /// Cache line size for alignment optimizations
 pub const CACHE_LINE_SIZE: usize = 64;
@@ -85,9 +109,15 @@ pub struct CacheAlignedChunks<'a, T> {
 
 impl<'a, T> CacheAlignedChunks<'a, T> {
     pub fn new(data: &'a [T]) -> Self {
+        // How many elements fill one `CACHE_CHUNK_SIZE` block, and never zero:
+        // an element wider than a cache line used to make the old
+        // `(CACHE_LINE_SIZE / element_size) * (CACHE_CHUNK_SIZE / CACHE_LINE_SIZE)`
+        // truncate to 0, and `next` then advanced `position` by nothing and
+        // yielded empty slices forever. This form agrees with the old one for
+        // every element size that divides a cache line, and yields one element
+        // per chunk for anything larger.
         let element_size = mem::size_of::<T>();
-        let elems_per_line = CACHE_LINE_SIZE / element_size.max(1);
-        let chunk_size = elems_per_line * (CACHE_CHUNK_SIZE / CACHE_LINE_SIZE);
+        let chunk_size = (CACHE_CHUNK_SIZE / element_size.max(1)).max(1);
         Self {
             data,
             chunk_size,
@@ -106,6 +136,9 @@ impl<'a, T> Iterator for CacheAlignedChunks<'a, T> {
         let end = (self.position + self.chunk_size).min(self.data.len());
         let chunk = &self.data[self.position..end];
         if end < self.data.len() {
+            // SAFETY: `end < self.data.len()`, so `add(end)` lands on a live
+            // element rather than one past the end, and prefetching only hints
+            // the cache — it neither reads nor writes.
             unsafe {
                 let next_ptr = self.data.as_ptr().add(end);
                 prefetch_read_data(next_ptr as *const u8, 3);
@@ -264,6 +297,11 @@ impl<'a, T: Sync> ZeroCopyParallelIter<'a, T> {
         }
 
         let mut results: Vec<MaybeUninit<R>> = Vec::with_capacity(self.data.len());
+        // SAFETY: the allocation holds `data.len()` elements and `MaybeUninit<R>`
+        // has no validity requirement, so growing the length to cover them
+        // exposes no uninitialized `R`. Every element is written by the fan-out
+        // below before the `assume_init` at the end, which both join paths
+        // enforce rather than assume (see the module docs).
         unsafe {
             results.set_len(self.data.len());
         }
@@ -327,7 +365,11 @@ impl<'a, T: Sync> ZeroCopyParallelIter<'a, T> {
             guard.wait();
         }
 
-        // Convert MaybeUninit<R> to R safely
+        // SAFETY: control only reaches here once every chunk reported
+        // completion — `pool_fallback_permitted` panics on a partially executed
+        // fan-out and `PoolJoinGuard::wait` panics on a missing completion — and
+        // the chunks partition `0..data.len()`, so each element was written
+        // exactly once.
         unsafe { results.into_iter().map(|item| item.assume_init()).collect() }
     }
 
@@ -455,6 +497,39 @@ mod tests {
     use super::*;
 
     struct NonClone(u64);
+
+    #[test]
+    fn cache_chunks_advance_for_elements_wider_than_a_cache_line() {
+        // Regression: the chunk size came from
+        // `(CACHE_LINE_SIZE / element_size) * (CACHE_CHUNK_SIZE / CACHE_LINE_SIZE)`,
+        // whose first term truncates to 0 once an element exceeds a cache line.
+        // `next` then clamped `end` to `position`, advanced by nothing, and
+        // yielded empty slices forever — an infinite iterator over any `T`
+        // bigger than 64 bytes.
+        #[repr(align(8))]
+        struct Wide([u64; 24]); // 192 bytes, three cache lines
+
+        let data: Vec<Wide> = (0..8).map(|i| Wide([i; 24])).collect();
+
+        // Bounded so the pre-fix behaviour fails the assertions instead of
+        // hanging the suite.
+        let chunks: Vec<&[Wide]> = data.cache_chunks().take(64).collect();
+
+        assert!(
+            chunks.iter().all(|chunk| !chunk.is_empty()),
+            "no chunk may be empty; an empty chunk means `position` did not advance"
+        );
+
+        let visited: Vec<u64> = chunks
+            .iter()
+            .flat_map(|chunk| chunk.iter().map(|wide| wide.0[0]))
+            .collect();
+        assert_eq!(
+            visited,
+            (0..8).collect::<Vec<u64>>(),
+            "chunks must cover every element exactly once, in order"
+        );
+    }
 
     #[test]
     fn test_window_iterator() {


### PR DESCRIPTION
Ninth increment of the moirai unsafe audit — `moirai-iter/src/cache.rs`, 14 unsafe sites with no safety comment. It contains the most serious defect the audit has found: a path that reads uninitialized memory.

## Defect 1 (UB): `map` can `assume_init` a slice no worker wrote

`ZeroCopyParallelIter::map` allocates `Vec<MaybeUninit<R>>`, `set_len`s it, fans chunk writes across workers, and then calls `assume_init` on **every** element. That is sound only if every chunk actually wrote. The executor path enforces it — `pool_fallback_permitted` panics on a partially executed fan-out. The pool fallback did not.

The fallback signalled completion with `tx.send(())` as each closure's last act, and the join was:

```rust
pub(crate) fn wait(mut self) {
    for _ in 0..self.count {
        let _ = self.rx.recv();   // <-- result discarded
    }
    self.count = 0;
}
```

The discarded `Result` is the bug. `ThreadPool`'s worker loop has no `catch_unwind`, so a panicking closure never reaches its `send` and drops its sender while unwinding. Once the last sender is gone, `recv` returns `Err` **immediately and forever** — the loop burns its remaining iterations instantly and `wait` returns exactly as if every task had finished. `map` then reads uninitialized memory.

Reaching it requires the fallback path (`Err(ShuttingDown)` from the global executor) plus a panicking user closure, so it is narrow — but it is UB, not merely a wrong answer.

The same discarded result made `for_each`, `reduce`, and the parallel sorts return **silently partial** results after a worker panic. Not unsound, but defect-masking.

**Fix at the root:** `wait` counts completions and panics unless every task reported one. That repairs all seven call sites across three files at once, rather than patching `map` alone. The failure then surfaces on the caller's thread before any consumer touches the buffer; the `MaybeUninit` elements leak rather than being read — the same trade `pool_fallback_permitted` already makes.

`Drop` deliberately keeps its unchecked drain: it can run while a panic is already unwinding, and asserting there would abort the process.

## Defect 2 (infinite loop): `CacheAlignedChunks` never advances for wide elements

```rust
let elems_per_line = CACHE_LINE_SIZE / element_size.max(1);
let chunk_size = elems_per_line * (CACHE_CHUNK_SIZE / CACHE_LINE_SIZE);
```

`CACHE_LINE_SIZE / element_size` truncates to **0** as soon as an element exceeds 64 bytes, so `chunk_size` is 0. `next` then clamps `end` to `position`, advances by nothing, and yields empty slices forever. Reachable from the public `cache_chunks()` on any slice of a type wider than a cache line.

Sizing straight from `CACHE_CHUNK_SIZE` and clamping to at least one element fixes it, and agrees with the old formula for every element size that divides a cache line.

## Also

- **Removed `SendConstPtr`** — an entirely `#[allow(dead_code)]` type whose only substance was an `unsafe impl Send` nothing used. Dead unsafe surface.
- **Module doc.** The file had 14 unsafe sites and no safety comment. Audit result: no other defect — the fan-out partitions with `chunks` so worker `i` owns `i * chunk_size` (disjoint, in bounds); the raw pointers refer to locals of the calling frame and every path joins before returning; and `map`'s `assume_init` is now genuinely gated on every chunk having run.

## Tests

Both regression tests are deterministic and fail on the pre-fix code **without hanging CI**:

- `pool_join_guard_rejects_a_missing_completion` — needs no threads at all. Fewer sends than tasks, then a dropped sender, is precisely the shape a panicking worker produces.
- `cache_chunks_advance_for_elements_wider_than_a_cache_line` — uses a 192-byte element and a bounded `take(64)`, asserting no chunk is empty and that the chunks cover every element exactly once in order. Pre-fix that yields 64 empty slices and fails the assertions rather than looping forever.

## Verification

- `cargo fmt -p moirai-iter -- --check` ✓
- `cargo clippy -p moirai-iter --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-iter` — 188/188 ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-iter` ✓

Audit progress: nine moirai files — five sound, four with defects found and fixed (async task re-entry #92, shared-memory sizing #93, errno discipline #94, and this pair).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two critical defects discovered during an unsafe code audit of `moirai-iter/src/cache.rs`. The first defect is a **memory safety issue** where `ZeroCopyParallelIter::map` could call `assume_init` on uninitialized memory if a worker thread panicked during the pooled fan-out execution, because the join logic discarded `recv()` results and couldn't distinguish between completed tasks and disconnected channels. The fix makes `PoolJoinGuard::wait` count completions and panic if any task fails to report, ensuring initialized memory before the `assume_init` call. The second defect is an **infinite loop** in `CacheAlignedChunks` where the chunk size calculation truncated to zero for elements wider than 64 bytes, causing the iterator to yield empty slices forever without advancing. The fix changes the chunk size formula to ensure at least one element per chunk. Both fixes include deterministic regression tests.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `moirai-iter/src/cache.rs` |
| 3 | `moirai-iter/src/base.rs` |
| 4 | `moirai-iter/src/base/tests.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->