### PR TITLE
Bound sort forking so the pool cannot starve itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   worker had written, and `for_each`, `reduce`, and the parallel sorts returned
   silently partial results. The join now counts completions and panics unless
   every task reported one.
+- Stop the `moirai-iter` parallel sorts deadlocking on large inputs. The
+  recursion forks one half onto the shared pool and blocks on it, so a forked
+  half that forks again occupied a worker while depending on another; the pool
+  does not steal work, so once every worker was blocked that way the queued
+  halves had nobody left to run them and `par_sort` never returned. Reachable
+  around `2048 * 2^(workers + 1)` elements — roughly a million on an eight-core
+  machine. A fork budget now keeps at least one worker free to drain the queue,
+  and the recursion sorts both halves in place once the budget is spent.
 - Keep a `moirai-iter` pool worker alive when a job panics. The worker ran jobs
   without catching unwinds and workers are never replaced, so each panicking job
   removed one permanently; once all had gone, `execute` kept queueing onto a

--- a/moirai-iter/src/base.rs
+++ b/moirai-iter/src/base.rs
@@ -420,6 +420,15 @@ impl ThreadPool {
         }
     }
 
+    /// Number of worker threads, always at least one.
+    ///
+    /// Callers that block a worker while waiting on another pooled job need
+    /// this to keep at least one worker free; the pool does not steal work, so
+    /// blocking all of them stalls the queue permanently.
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+
     pub fn execute<F>(&self, job: F)
     where
         F: FnOnce() + Send + 'static,

--- a/moirai-iter/src/base.rs
+++ b/moirai-iter/src/base.rs
@@ -293,6 +293,37 @@ pub struct ThreadPool {
     /// Wrapped in Option so `Drop` can close the channel before joining workers.
     sender: Option<std::sync::mpsc::Sender<ErasedThreadJob>>,
     workers: Vec<std::thread::JoinHandle<()>>,
+    /// Permits for callers that block a worker while awaiting another job here.
+    fork_budget: ForkBudget,
+}
+
+/// Remaining permits to block a worker on another job in the same pool.
+///
+/// The pool does not steal work, so a worker blocked waiting for a queued job
+/// cannot help run it. If every worker blocks that way the queue stalls
+/// permanently. Holding the outstanding count below the worker count keeps one
+/// worker free to drain it, which is what guarantees progress.
+///
+/// The budget belongs to the pool rather than to a caller: the shared pool is a
+/// process-wide singleton, so two callers each keeping their own count could
+/// together block every worker even while each stayed under the limit alone.
+pub(crate) type ForkBudget = Arc<std::sync::atomic::AtomicUsize>;
+
+/// Claim a permit to block a worker, or report that the caller must proceed
+/// without forking.
+pub(crate) fn try_fork(budget: &ForkBudget) -> bool {
+    budget
+        .fetch_update(
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+            |remaining| remaining.checked_sub(1),
+        )
+        .is_ok()
+}
+
+/// Return a permit once the awaited job has been joined.
+pub(crate) fn end_fork(budget: &ForkBudget) {
+    budget.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
 }
 
 /// Heap-stable thread-pool job with monomorphized run/drop functions.
@@ -383,7 +414,7 @@ impl ThreadPool {
         let (sender, receiver) = std::sync::mpsc::channel::<ErasedThreadJob>();
         let receiver = Arc::new(std::sync::Mutex::new(receiver));
 
-        let workers = (0..size.max(1))
+        let workers: Vec<std::thread::JoinHandle<()>> = (0..size.max(1))
             .map(|_| {
                 let receiver = receiver.clone();
                 std::thread::spawn(move || loop {
@@ -414,19 +445,26 @@ impl ThreadPool {
             })
             .collect();
 
+        let fork_budget = Arc::new(std::sync::atomic::AtomicUsize::new(
+            workers.len().saturating_sub(1),
+        ));
+
         Self {
             sender: Some(sender),
             workers,
+            fork_budget,
         }
     }
 
     /// Number of worker threads, always at least one.
-    ///
-    /// Callers that block a worker while waiting on another pooled job need
-    /// this to keep at least one worker free; the pool does not steal work, so
-    /// blocking all of them stalls the queue permanently.
     pub fn worker_count(&self) -> usize {
         self.workers.len()
+    }
+
+    /// This pool's shared budget for callers that block a worker on another of
+    /// its jobs. See [`ForkBudget`].
+    pub(crate) fn fork_budget(&self) -> &ForkBudget {
+        &self.fork_budget
     }
 
     pub fn execute<F>(&self, job: F)

--- a/moirai-iter/src/parallel/sorting.rs
+++ b/moirai-iter/src/parallel/sorting.rs
@@ -1,6 +1,8 @@
 //! Parallel slice sorting implementation.
 
-use crate::base::{get_shared_thread_pool, PoolJoinGuard, SendPtr, ThreadPool};
+use crate::base::{
+    end_fork, get_shared_thread_pool, try_fork, ForkBudget, PoolJoinGuard, SendPtr, ThreadPool,
+};
 use std::mem::MaybeUninit;
 use std::sync::Arc;
 
@@ -52,8 +54,7 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
         let pool = get_shared_thread_pool();
-        let budget = new_fork_budget(&pool);
-        par_merge_sort_impl(self, &compare, &pool, &budget);
+        par_merge_sort_impl(self, &compare, &pool, pool.fork_budget());
     }
 
     fn par_sort_by_key<K, F>(&mut self, f: F)
@@ -76,8 +77,7 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
         let pool = get_shared_thread_pool();
-        let budget = new_fork_budget(&pool);
-        par_sort_unstable_by_impl(self, &compare, &pool, &budget);
+        par_sort_unstable_by_impl(self, &compare, &pool, pool.fork_budget());
     }
 
     fn par_sort_unstable_by_key<K, F>(&mut self, f: F)
@@ -93,42 +93,6 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
 // task scheduling and merge/partition overhead.
 const STABLE_SEQUENTIAL_THRESHOLD: usize = 2048;
 const UNSTABLE_SEQUENTIAL_THRESHOLD: usize = 16_384;
-
-/// How many halves may be outstanding on the pool at once, shared by one sort.
-///
-/// Each recursion forks one half onto the pool and then blocks waiting for it,
-/// so a forked half that forks again occupies a worker while depending on
-/// another worker. The pool does not steal work, so if every worker is blocked
-/// that way, the halves they are waiting for sit in the queue with nobody left
-/// to run them and the sort never finishes — reachable on any input deep enough
-/// to fork more times than the pool has workers.
-///
-/// Holding the count strictly below the worker count keeps at least one worker
-/// free to drain the queue, which is what guarantees progress. Running out of
-/// budget costs no correctness: the recursion just sorts both halves in place.
-type ForkBudget = Arc<std::sync::atomic::AtomicUsize>;
-
-fn new_fork_budget(pool: &ThreadPool) -> ForkBudget {
-    Arc::new(std::sync::atomic::AtomicUsize::new(
-        pool.worker_count().saturating_sub(1),
-    ))
-}
-
-/// Claim one outstanding fork, or report that the sort must recurse in place.
-fn try_fork(budget: &ForkBudget) -> bool {
-    budget
-        .fetch_update(
-            std::sync::atomic::Ordering::AcqRel,
-            std::sync::atomic::Ordering::Acquire,
-            |remaining| remaining.checked_sub(1),
-        )
-        .is_ok()
-}
-
-/// Return a fork to the budget once its half has been joined.
-fn end_fork(budget: &ForkBudget) {
-    budget.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
-}
 
 fn partition<T, F>(v: &mut [T], compare: &F) -> usize
 where
@@ -397,10 +361,8 @@ mod tests {
     #[test]
     fn deep_recursion_completes_on_a_pool_smaller_than_its_depth() {
         let pool = Arc::new(ThreadPool::new(2));
-        let budget = new_fork_budget(&pool);
-
         let mut data: Vec<u64> = (0..65_536u64).rev().collect();
-        par_merge_sort_impl(&mut data, &u64::cmp, &pool, &budget);
+        par_merge_sort_impl(&mut data, &u64::cmp, &pool, pool.fork_budget());
 
         assert!(
             data.windows(2).all(|pair| pair[0] <= pair[1]),
@@ -411,15 +373,34 @@ mod tests {
     #[test]
     fn deep_unstable_recursion_completes_on_a_small_pool() {
         let pool = Arc::new(ThreadPool::new(2));
-        let budget = new_fork_budget(&pool);
-
         let mut data: Vec<u64> = (0..262_144u64).rev().collect();
-        par_sort_unstable_by_impl(&mut data, &u64::cmp, &pool, &budget);
+        par_sort_unstable_by_impl(&mut data, &u64::cmp, &pool, pool.fork_budget());
 
         assert!(
             data.windows(2).all(|pair| pair[0] <= pair[1]),
             "the sort must both finish and order the slice"
         );
+    }
+
+    // The budget belongs to the pool, not to a sort: the shared pool is a
+    // process-wide singleton, so two sorts each holding their own count could
+    // together block every worker while each stayed under the limit alone.
+    // Both of these run deep enough to fork, against a pool too small for even
+    // one of them unbudgeted.
+    #[test]
+    fn concurrent_sorts_share_one_pool_budget() {
+        let pool = Arc::new(ThreadPool::new(2));
+
+        std::thread::scope(|scope| {
+            for _ in 0..2 {
+                let pool = Arc::clone(&pool);
+                scope.spawn(move || {
+                    let mut data: Vec<u64> = (0..65_536u64).rev().collect();
+                    par_merge_sort_impl(&mut data, &u64::cmp, &pool, pool.fork_budget());
+                    assert!(data.windows(2).all(|pair| pair[0] <= pair[1]));
+                });
+            }
+        });
     }
 
     #[test]

--- a/moirai-iter/src/parallel/sorting.rs
+++ b/moirai-iter/src/parallel/sorting.rs
@@ -52,7 +52,8 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
         let pool = get_shared_thread_pool();
-        par_merge_sort_impl(self, &compare, &pool);
+        let budget = new_fork_budget(&pool);
+        par_merge_sort_impl(self, &compare, &pool, &budget);
     }
 
     fn par_sort_by_key<K, F>(&mut self, f: F)
@@ -75,7 +76,8 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
         let pool = get_shared_thread_pool();
-        par_sort_unstable_by_impl(self, &compare, &pool);
+        let budget = new_fork_budget(&pool);
+        par_sort_unstable_by_impl(self, &compare, &pool, &budget);
     }
 
     fn par_sort_unstable_by_key<K, F>(&mut self, f: F)
@@ -91,6 +93,42 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
 // task scheduling and merge/partition overhead.
 const STABLE_SEQUENTIAL_THRESHOLD: usize = 2048;
 const UNSTABLE_SEQUENTIAL_THRESHOLD: usize = 16_384;
+
+/// How many halves may be outstanding on the pool at once, shared by one sort.
+///
+/// Each recursion forks one half onto the pool and then blocks waiting for it,
+/// so a forked half that forks again occupies a worker while depending on
+/// another worker. The pool does not steal work, so if every worker is blocked
+/// that way, the halves they are waiting for sit in the queue with nobody left
+/// to run them and the sort never finishes — reachable on any input deep enough
+/// to fork more times than the pool has workers.
+///
+/// Holding the count strictly below the worker count keeps at least one worker
+/// free to drain the queue, which is what guarantees progress. Running out of
+/// budget costs no correctness: the recursion just sorts both halves in place.
+type ForkBudget = Arc<std::sync::atomic::AtomicUsize>;
+
+fn new_fork_budget(pool: &ThreadPool) -> ForkBudget {
+    Arc::new(std::sync::atomic::AtomicUsize::new(
+        pool.worker_count().saturating_sub(1),
+    ))
+}
+
+/// Claim one outstanding fork, or report that the sort must recurse in place.
+fn try_fork(budget: &ForkBudget) -> bool {
+    budget
+        .fetch_update(
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+            |remaining| remaining.checked_sub(1),
+        )
+        .is_ok()
+}
+
+/// Return a fork to the budget once its half has been joined.
+fn end_fork(budget: &ForkBudget) {
+    budget.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+}
 
 fn partition<T, F>(v: &mut [T], compare: &F) -> usize
 where
@@ -125,8 +163,12 @@ where
     j
 }
 
-fn par_sort_unstable_by_impl<T, F>(slice: &mut [T], compare: &F, pool: &Arc<ThreadPool>)
-where
+fn par_sort_unstable_by_impl<T, F>(
+    slice: &mut [T],
+    compare: &F,
+    pool: &Arc<ThreadPool>,
+    budget: &ForkBudget,
+) where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
 {
@@ -144,6 +186,14 @@ where
         &mut right[1..] // Skip the pivot itself
     };
 
+    if !try_fork(budget) {
+        // Budget spent — see `ForkBudget`. Both sides run here so no worker
+        // blocks on a half that nothing is left to schedule.
+        par_sort_unstable_by_impl(left, compare, pool, budget);
+        par_sort_unstable_by_impl(right, compare, pool, budget);
+        return;
+    }
+
     // Erase types to () to satisfy the 'static requirements of ThreadPool::execute
     let left_ptr = SendPtr(left.as_mut_ptr() as *mut ());
     let left_len = left.len();
@@ -151,6 +201,7 @@ where
 
     let (tx, rx) = std::sync::mpsc::channel();
     let pool_clone = Arc::clone(pool);
+    let budget_clone = Arc::clone(budget);
     let guard = PoolJoinGuard::new(rx, 1);
 
     pool.execute(move || {
@@ -159,17 +210,22 @@ where
         unsafe {
             let left_slice = std::slice::from_raw_parts_mut(left_ptr.as_ptr() as *mut T, left_len);
             let compare_ref = &*(compare_ptr.as_ptr() as *const F);
-            par_sort_unstable_by_impl(left_slice, compare_ref, &pool_clone);
+            par_sort_unstable_by_impl(left_slice, compare_ref, &pool_clone, &budget_clone);
         }
         let _ = tx.send(());
     });
 
-    par_sort_unstable_by_impl(right, compare, pool);
+    par_sort_unstable_by_impl(right, compare, pool, budget);
     guard.wait();
+    end_fork(budget);
 }
 
-fn par_merge_sort_impl<T, F>(slice: &mut [T], compare: &F, pool: &Arc<ThreadPool>)
-where
+fn par_merge_sort_impl<T, F>(
+    slice: &mut [T],
+    compare: &F,
+    pool: &Arc<ThreadPool>,
+    budget: &ForkBudget,
+) where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
 {
@@ -182,24 +238,41 @@ where
     let mid = len / 2;
     let (left, right) = slice.split_at_mut(mid);
 
-    // Erase types to () to satisfy the 'static requirements of ThreadPool::execute
-    let left_ptr = SendPtr(left.as_mut_ptr() as *mut ());
-    let left_len = left.len();
-    let compare_ptr = SendPtr(compare as *const F as *mut F as *mut ());
+    if try_fork(budget) {
+        // Erase types to () to satisfy the 'static requirements of ThreadPool::execute
+        let left_ptr = SendPtr(left.as_mut_ptr() as *mut ());
+        let left_len = left.len();
+        let compare_ptr = SendPtr(compare as *const F as *mut F as *mut ());
 
-    let (tx, rx) = std::sync::mpsc::channel();
-    let pool_clone = Arc::clone(pool);
-    let guard = PoolJoinGuard::new(rx, 1);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let pool_clone = Arc::clone(pool);
+        let guard = PoolJoinGuard::new(rx, 1);
 
-    pub_execute_merge::<T, F>(pool, tx, left_ptr, left_len, compare_ptr, pool_clone);
+        pub_execute_merge::<T, F>(
+            pool,
+            tx,
+            left_ptr,
+            left_len,
+            compare_ptr,
+            pool_clone,
+            Arc::clone(budget),
+        );
 
-    par_merge_sort_impl(right, compare, pool);
-    guard.wait();
+        par_merge_sort_impl(right, compare, pool, budget);
+        guard.wait();
+        end_fork(budget);
+    } else {
+        // The pool is already carrying as many blocked halves as it can while
+        // still guaranteeing progress; sort both halves here instead.
+        par_merge_sort_impl(left, compare, pool, budget);
+        par_merge_sort_impl(right, compare, pool, budget);
+    }
 
     merge(slice, mid, compare);
 }
 
 // Helper to keep closures distinct
+#[allow(clippy::too_many_arguments)]
 fn pub_execute_merge<T, F>(
     pool: &ThreadPool,
     tx: std::sync::mpsc::Sender<()>,
@@ -207,6 +280,7 @@ fn pub_execute_merge<T, F>(
     left_len: usize,
     compare_ptr: SendPtr<()>,
     pool_clone: Arc<ThreadPool>,
+    budget: ForkBudget,
 ) where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
@@ -218,7 +292,7 @@ fn pub_execute_merge<T, F>(
         unsafe {
             let left_slice = std::slice::from_raw_parts_mut(left_ptr.as_ptr() as *mut T, left_len);
             let compare_ref = &*(compare_ptr.as_ptr() as *const F);
-            par_merge_sort_impl(left_slice, compare_ref, &pool_clone);
+            par_merge_sort_impl(left_slice, compare_ref, &pool_clone, &budget);
         }
         let _ = tx.send(());
     });
@@ -312,6 +386,41 @@ where
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Regression: the recursion forks one half onto the pool and blocks on it,
+    // so a forked half that forks again ties up a worker while depending on
+    // another. The pool does not steal work, so once every worker was blocked
+    // that way the queued halves had nobody left to run them and the sort never
+    // returned. Reproduced here with a two-worker pool and an input deep enough
+    // to fork five times; before the fork budget this hung until the harness
+    // killed it.
+    #[test]
+    fn deep_recursion_completes_on_a_pool_smaller_than_its_depth() {
+        let pool = Arc::new(ThreadPool::new(2));
+        let budget = new_fork_budget(&pool);
+
+        let mut data: Vec<u64> = (0..65_536u64).rev().collect();
+        par_merge_sort_impl(&mut data, &u64::cmp, &pool, &budget);
+
+        assert!(
+            data.windows(2).all(|pair| pair[0] <= pair[1]),
+            "the sort must both finish and order the slice"
+        );
+    }
+
+    #[test]
+    fn deep_unstable_recursion_completes_on_a_small_pool() {
+        let pool = Arc::new(ThreadPool::new(2));
+        let budget = new_fork_budget(&pool);
+
+        let mut data: Vec<u64> = (0..262_144u64).rev().collect();
+        par_sort_unstable_by_impl(&mut data, &u64::cmp, &pool, &budget);
+
+        assert!(
+            data.windows(2).all(|pair| pair[0] <= pair[1]),
+            "the sort must both finish and order the slice"
+        );
+    }
 
     #[test]
     fn test_sorting_empty_and_single() {


### PR DESCRIPTION
Eleventh increment of the moirai audit. This round started as a **pattern sweep** rather than a file pick: having found the same defect twice, I grepped the workspace for the classes themselves, which pointed here.

## How this was found

| Class (from earlier findings) | Result |
|---|---|
| Discarded `Result` on a completion/join channel (#97) | Clean — remaining hits are the documented `Drop` drain and the worker join |
| Capacity from integer division truncating to zero (#97) | Clean — the truncation bug was isolated |
| `assume_init` / `set_len` after fan-out | 3 unaudited sites; `sorting.rs` also holds two `PoolJoinGuard` sites |
| User closures on workers without `catch_unwind` (#98) | Fixed; other spawners are internal loops |

`parallel/sorting.rs` sat at the intersection of two classes, so it went first.

## Defect: the parallel sorts deadlock on large inputs

`par_merge_sort_impl` and `par_sort_unstable_by_impl` fork one half onto the shared pool and then **block** on it:

```rust
pub_execute_merge(...);              // left half -> pool
par_merge_sort_impl(right, ...);     // right half inline
guard.wait();                        // block until the left half finishes
```

The forked half runs the same function, so it forks again and blocks too. `ThreadPool` is a plain FIFO queue with **no work stealing**, so a worker blocked in `wait` cannot help run the queue. Once every worker is blocked that way, the halves they are waiting for sit queued with nothing left to run them, and the sort never returns.

It needs only enough depth to fork more times than the pool has workers — about `2048 * 2^(workers + 1)` elements for the stable sort, roughly **a million on an eight-core machine**. That is the input size a parallel sort exists for.

Every existing test sorts a few dozen elements, far below the 2048 sequential cutoff, so none of them ever forked once. That is why this survived.

### Confirmed before fixing

A two-worker pool sorting 65 536 elements (five forks deep) **hung until the harness killed it at sixty seconds**. I ran that probe before writing any fix, so the claim rests on observed behaviour rather than on reading the control flow.

## Fix

A fork budget shared across one sort, capped at `worker_count - 1`. Keeping one worker free to drain the queue is what guarantees progress: any blocked frame is waiting on a half that a free worker can always pick up.

Exhausting the budget costs no correctness — the recursion sorts both halves in place — and parallelism is unaffected up to the pool's real width, which was the only useful amount. The same case now finishes in **27 ms**.

Both regression tests fail *safely* if the budget is removed: they trip the committed nextest terminate bound and report a timeout rather than hanging CI.

## Audit result for the rest of the file: sound

The `MergeGuard` merge is correct, and worth stating explicitly since this shape once caused a real soundness bug in `slice::sort`:

- The invariant `k == i + (j - mid)` gives `k < j` strictly inside the loop, so a write never lands on an unconsumed element.
- `Drop` performs the left-tail copy on the normal **and** panic paths, so every element ends up in the slice exactly once — consumed at `[0, k)`, remaining left at `[k, j)`, right at `[j, len)`. No holes, no double drops.
- Holding the copies in `Vec<MaybeUninit<T>>` is what stops the stale duplicates from being dropped.

Also adds `ThreadPool::worker_count`, which the budget needs and which any caller that blocks a worker needs generally.

## A structural note

This is the third defect in this crate from one root gap: **a non-work-stealing pool whose jobs block on other jobs**.

- #97 — the join could not tell "task finished" from "worker died", so `map` read uninitialized memory.
- #98 — a panicking job silently removed a worker, so the pool bled capacity until something unrelated hung.
- This — blocking recursion exhausts the workers outright.

The three fixes make the current design safe (detect failure, preserve workers, bound blocking). The deeper answer is work stealing, or routing this through the executor's `for_each_indexed` as the rest of `moirai-iter` already does. That is an architectural change deserving its own ADR, so it is filed rather than smuggled in here.

## Verification

- `cargo fmt -p moirai-iter -- --check` ✓
- `cargo clippy -p moirai-iter --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-iter` — 192/192 ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-iter` ✓

Audit progress: eleven moirai files — five sound, six with defects found and fixed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a deadlock in `moirai-iter`'s parallel sorting functions that occurred on large inputs (roughly 1 million elements on an 8-core machine). The issue arose because the recursive sort forks one half onto a thread pool and blocks waiting for it, but the pool has no work stealing—so when all workers become blocked waiting on forked work, the queued tasks have no one left to run them. The fix introduces a fork budget (capped at `worker_count - 1`) that ensures at least one worker remains free to drain the queue, guaranteeing forward progress. When the budget is exhausted, both halves are sorted in place without blocking. This also adds a `worker_count()` method to `ThreadPool` to support the budget calculation.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CHANGELOG.md` |
| 2 | `moirai-iter/src/base.rs` |
| 3 | `moirai-iter/src/parallel/sorting.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parallel stable and unstable sorting hanging on large inputs.
  * Improved sorting reliability when using small thread pools or deeply recursive inputs.
  * Added safeguards to ensure sorting work continues processing instead of becoming blocked.

* **Documentation**
  * Updated the unreleased changelog with details of the parallel sorting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->