### PR TITLE
Cover the chunked path in ParallelIter

### DIFF
--- a/moirai-iter/src/iter_ops/parallel.rs
+++ b/moirai-iter/src/iter_ops/parallel.rs
@@ -4,6 +4,43 @@
 //! scoped worker threads. The invariant is `owner(Vec<T>) XOR borrowed chunks`:
 //! no worker owns or refcounts the vector, and all borrows end before the
 //! vector is dropped.
+//!
+//! # Fan-out safety
+//!
+//! Both operations hand workers three raw pointers wrapped in `SendPtr` — the
+//! chunk, the caller's closure, and the output slot — because the borrow checker
+//! cannot see that the chunks partition the input. What makes that sound:
+//!
+//! - **Disjoint writes.** Worker `idx` writes only `results[idx]`, and the
+//!   chunks partition the input, so no two workers touch the same output slot or
+//!   read overlapping data.
+//! - **Shared reads only.** The closure and the chunk are reached as `&F` and
+//!   `&[T]`; nothing is written through them. The `F: Sync` and `T: Sync` bounds
+//!   are what let several workers hold those references at once. The
+//!   `*const _ as *mut _` casts are an artifact of erasing the type through
+//!   `SendPtr`, not a claim of unique access.
+//! - **Lifetime.** Every pointer refers to a local of this frame — the vector,
+//!   the closure, the results — and both dispatch paths block before returning:
+//!   the executor call joins internally, and the pool path joins in
+//!   `PoolJoinGuard::wait`. No worker outlives what it points at.
+//! - **Completion.** `results` starts as `None` per chunk and the tail
+//!   `flatten()` silently drops any that stayed `None`, so a chunk that never
+//!   ran would quietly shorten a `map` or omit a term from a `reduce`. Neither
+//!   join path allows that: `pool_fallback_permitted` panics on a partially
+//!   executed fan-out, and `wait` panics unless every task reported completion.
+//!
+//! Because the outputs are `Option<_>` rather than `MaybeUninit`, a skipped
+//! chunk here would be a wrong answer rather than a read of uninitialized
+//! memory — which is why the completion guarantee is the load-bearing one.
+//!
+//! # Dispatch threshold
+//!
+//! Work is only chunked out when `len > chunk_size` and the chunk itself clears
+//! `DEFAULT_RING_BUFFER_CAPACITY`; anything smaller runs sequentially, where
+//! none of the above applies. `chunk_size` is derived from the parallelism of
+//! the host, so whether a given input takes the parallel path is machine
+//! dependent — tests that need to cover it construct the iterator with an
+//! explicit chunk size rather than relying on the core count.
 
 use crate::base::{get_shared_thread_pool, PoolJoinGuard, SendPtr};
 /// Default ring buffer capacity (power of 2)
@@ -56,6 +93,10 @@ impl<T: Send + Sync> ParallelIter<T> {
         let f_ptr_send = SendPtr(&f as *const F as *const () as *mut ());
 
         let run_on_global = moirai_executor::global()
+            // SAFETY: `idx < num_chunks` indexes `chunks` and `results` alike,
+            // so the chunk is a live borrow of `data` and the write lands on
+            // this worker's own slot. `f` outlives the call because the fan-out
+            // joins before returning, and is only read, which `F: Sync` allows.
             .for_each_indexed::<moirai_executor::schedule::SyncTask, _>(num_chunks, |idx| unsafe {
                 let chunk = *chunks.get_unchecked(idx);
                 let chunk_ptr = chunk.as_ptr();
@@ -76,6 +117,10 @@ impl<T: Send + Sync> ParallelIter<T> {
                 let chunk_len = chunk.len();
 
                 pool.execute(move || {
+                    // SAFETY: as the executor path — `idx` is this chunk's own
+                    // slot, the chunk pointer is a live borrow of `data`, and
+                    // `guard.wait()` below keeps this frame alive until every
+                    // worker has finished with all three pointers.
                     unsafe {
                         let chunk_slice =
                             std::slice::from_raw_parts(chunk_ptr.as_ptr() as *const T, chunk_len);
@@ -130,6 +175,9 @@ impl<T: Send + Sync> ParallelIter<T> {
         let f_ptr_send = SendPtr(&f as *const F as *const () as *mut ());
 
         let run_on_global = moirai_executor::global()
+            // SAFETY: as `map`, plus `chunk_identities`, which holds one entry
+            // per chunk and is only ever read here — worker `idx` clones its own
+            // and never writes through the pointer.
             .for_each_indexed::<moirai_executor::schedule::SyncTask, _>(num_chunks, |idx| unsafe {
                 let chunk = *chunks.get_unchecked(idx);
                 let chunk_ptr = chunk.as_ptr();
@@ -151,6 +199,9 @@ impl<T: Send + Sync> ParallelIter<T> {
                 let chunk_len = chunk.len();
 
                 pool.execute(move || {
+                    // SAFETY: as the executor path; `guard.wait()` below keeps
+                    // this frame alive until every worker is done with the
+                    // chunk, closure, identity, and result pointers.
                     unsafe {
                         let chunk_slice =
                             std::slice::from_raw_parts(chunk_ptr.as_ptr() as *const T, chunk_len);
@@ -187,4 +238,65 @@ fn chunk_size(len: usize) -> usize {
 #[inline]
 fn should_execute_scoped(len: usize, chunk_size: usize) -> bool {
     len > chunk_size && chunk_size > DEFAULT_RING_BUFFER_CAPACITY
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an iterator that is guaranteed to take the chunked path.
+    ///
+    /// `new` derives the chunk size from the host's parallelism, so on any
+    /// machine an input has to be large enough that `len / cores` still clears
+    /// `DEFAULT_RING_BUFFER_CAPACITY` before the fan-out runs at all. Setting the
+    /// size directly makes the coverage independent of the core count.
+    fn chunked<T: Send + Sync>(data: Vec<T>, chunk_size: usize) -> ParallelIter<T> {
+        assert!(
+            should_execute_scoped(data.len(), chunk_size),
+            "the fixture must reach the parallel path, not the sequential fallback"
+        );
+        ParallelIter { data, chunk_size }
+    }
+
+    const CHUNK: usize = DEFAULT_RING_BUFFER_CAPACITY + 1;
+    const LEN: usize = CHUNK * 4 + 7; // several chunks plus a short remainder
+
+    #[test]
+    fn parallel_map_matches_the_sequential_result() {
+        let data: Vec<u64> = (0..LEN as u64).collect();
+        let expected: Vec<u64> = data.iter().map(|value| value * 3).collect();
+
+        let mapped = chunked(data, CHUNK).map(|value| value * 3);
+
+        assert_eq!(
+            mapped, expected,
+            "the chunked map must preserve every element and its order"
+        );
+    }
+
+    #[test]
+    fn parallel_reduce_matches_the_sequential_fold() {
+        let data: Vec<u64> = (0..LEN as u64).collect();
+        let expected: u64 = data.iter().sum();
+
+        let reduced = chunked(data, CHUNK).reduce(0, |sum, value| sum + value);
+
+        assert_eq!(
+            reduced, expected,
+            "every chunk's partial fold must reach the final result"
+        );
+    }
+
+    #[test]
+    fn parallel_map_covers_a_ragged_final_chunk() {
+        // The last chunk is shorter than the rest; a length or offset derived
+        // from `chunk_size` rather than the chunk itself would drop or duplicate
+        // its elements.
+        let data: Vec<u64> = (0..LEN as u64).collect();
+
+        let mapped = chunked(data, CHUNK).map(|value| *value);
+
+        assert_eq!(mapped.len(), LEN);
+        assert_eq!(mapped.last(), Some(&(LEN as u64 - 1)));
+    }
 }


### PR DESCRIPTION
Twelfth increment of the moirai audit — `moirai-iter/src/iter_ops/parallel.rs`, the last unaudited member of the `SendPtr` + `PoolJoinGuard` fan-out family that produced #97, #98 and #99. Four unsafe sites, ten fan-out references, no safety comment anywhere.

## Audit result: sound

- **Disjoint writes.** Worker `idx` writes only `results[idx]`, and the chunks partition the input.
- **Shared reads only.** The closure and chunk are reached as `&F` and `&[T]` and never written through; `F: Sync` and `T: Sync` license the concurrent access. The `*const _ as *mut _` casts are artifacts of erasing the type through `SendPtr`, not a claim of unique access.
- **Lifetime.** Every pointer refers to a local of the calling frame, and both dispatch paths block before it dies — the executor call joins internally, the pool path in `PoolJoinGuard::wait`.
- **Completion.** `results` is `Option<_>` filled with `None`, and the tail `flatten()` silently drops anything still `None`, so a chunk that never ran would quietly shorten a `map` or omit a term from a `reduce`. Neither join path allows it: `pool_fallback_permitted` panics on a partially executed fan-out, and `wait` panics unless every task reported completion.

Worth noting *why* this file escapes the UB its sibling had: `cache.rs` wrote through `MaybeUninit`, so a skipped chunk there was a read of uninitialized memory (#97). Here the same scenario is merely a wrong answer. That is a difference in output representation, not something the fan-out logic does differently — which makes the completion guarantee from #97/#98 the load-bearing invariant for this file too. It is now written down instead of implicit.

## The actual finding: the parallel path has never been executed

Dispatch requires:

```rust
fn should_execute_scoped(len: usize, chunk_size: usize) -> bool {
    len > chunk_size && chunk_size > DEFAULT_RING_BUFFER_CAPACITY   // 1024
}
```

`chunk_size` comes from `len.div_ceil(cores).max(1)`, so `chunk_size <= len`. Every existing test builds from at most 1024 elements, which makes `chunk_size <= 1024` and the second condition **unsatisfiable** — not unlikely, impossible.

So all four unsafe sites are untested. That includes `prop_parallel_map_matches_sequential` and `prop_parallel_reduce_matches_sequential`, whose stated purpose is that the parallel result equals the sequential reference: both have been comparing the sequential path against itself.

This is the same blind spot that concealed the sort deadlock in #99 — a threshold-gated fast path plus a suite that never crosses the threshold. Two files, one shape; worth treating as a place to look rather than a coincidence.

## Fix: coverage, not code

The tests construct the iterator with an explicit chunk size, so the fan-out is reached on any core count instead of depending on the machine, and the fixture asserts up front that it really does take that path rather than silently falling back. Three cases, each against a sequential oracle:

- `parallel_map_matches_the_sequential_result`
- `parallel_reduce_matches_the_sequential_fold`
- `parallel_map_covers_a_ragged_final_chunk` — the last chunk is shorter than the others, so a length or offset derived from `chunk_size` rather than the chunk itself would drop or duplicate elements.

Plus a module section and a comment at each unsafe site, covering the contract above.

## Verification

- `cargo fmt -p moirai-iter -- --check` ✓
- `cargo clippy -p moirai-iter --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-iter` — 196/196 ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-iter` ✓

Audit progress: twelve moirai files — six sound, six with defects found and fixed. This closes the fan-out family; the structural question underneath it (a FIFO pool used as a fork-join runtime) is filed as an ADR rather than answered here.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive documentation and test coverage to the parallel iteration code path in `ParallelIter`. The audit revealed that while the existing unsafe code was sound, the parallel execution path was never actually being tested because test inputs were too small to trigger the chunked dispatch threshold (1024 elements). The PR adds detailed safety comments explaining the disjoint writes, shared reads, lifetime, and completion guarantees for the fan-out pattern, and introduces three new tests that explicitly construct iterators with large enough chunk sizes to exercise the parallel code paths and verify correctness against sequential reference implementations.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-iter/src/iter_ops/parallel.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->