### PR TITLE
fix(iter): Run nested fork-join on the scheduler scope (ADR-022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Run the `moirai-iter` parallel sorts' recursive fork-join on the unified
+  scheduler's scope instead of the crate's own thread pool. That pool is a FIFO
+  queue with no work stealing, so a worker blocked on another of its jobs could
+  not run it — the starvation that the fork budget guarded against, at the cost
+  of capping the work tree at the pool's width. A scheduler worker waiting
+  inside a scope runs queued work instead of parking, so the budget is gone and
+  the recursion is deadlock-free by construction. A fork the scheduler refuses,
+  while shutting down or under admission backpressure, now runs on the calling
+  lane rather than being dropped. Splitting stops once a sub-slice is smaller
+  than `len / (workers * 8)` so fork count follows machine width rather than
+  input size. `ThreadPool` remains for flat fan-out only.
+
 ### Added
 
 - Expose a borrowing `moirai_parallel::scope` surface over the unified

--- a/benchmarks/benches/result_handle_diagnostics/types.rs
+++ b/benchmarks/benches/result_handle_diagnostics/types.rs
@@ -37,6 +37,7 @@ const MAX_INLINE_CAPTURE_WORDS: usize = 14;
 const OVERSIZED_CAPTURE_WORDS: usize = 32;
 const OVERSIZED_CAPTURED_READY_VALUE: usize = OVERSIZED_CAPTURE_WORDS;
 /// Maximum spin attempts in the blocking wait policy
+#[cfg(feature = "result-diagnostics")]
 const MAX_SPIN_ATTEMPTS: usize = 64;
 const TASK_ID: TaskId = TaskId(1);
 const BLOCKING_NORMAL_WORKER: usize = 3;

--- a/benchmarks/benches/sorting_comparison.rs
+++ b/benchmarks/benches/sorting_comparison.rs
@@ -8,83 +8,114 @@ use std::time::Duration;
 const SAMPLE_SIZE: usize = 10;
 const MEASUREMENT_MILLIS: u64 = 750;
 const WARM_UP_MILLIS: u64 = 250;
+
+/// Small input: recursion stays shallow, so this row measures per-call overhead
+/// rather than the parallel decomposition.
 const WORK_ITEMS: usize = 10_000;
 
-fn generate_random_data() -> Vec<i32> {
+/// Large input: `WORK_ITEMS` forks only a handful of times, which is why it
+/// could not observe the fork ceiling ADR-022 removes. At this size the stable
+/// sort decomposes into ~2000 leaves (`len / 2048`) and the unstable sort into
+/// ~250, both far past any worker count, so the row measures how much of the
+/// work tree the runtime actually spreads.
+const LARGE_ITEMS: usize = 4_000_000;
+
+fn generate_random_data(items: usize) -> Vec<i32> {
     let mut seed: u64 = 54321;
     let mut random_u32 = move || {
         seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
         seed as u32
     };
 
-    let mut data = Vec::with_capacity(WORK_ITEMS);
-    for _ in 0..WORK_ITEMS {
+    let mut data = Vec::with_capacity(items);
+    for _ in 0..items {
         data.push((random_u32() % 100_000) as i32);
     }
     data
 }
 
-fn sorting_comparison(c: &mut Criterion) {
-    let data = generate_random_data();
-
-    // Verify correctness first
-    let mut moirai_stable = data.clone();
+/// Assert the two implementations agree before either is timed: a benchmark of
+/// a wrong sort measures nothing.
+fn assert_agrees_with_rayon(data: &[i32]) {
+    let mut moirai_stable = data.to_vec();
     MoiraiParallelSliceMut::par_sort(moirai_stable.as_mut_slice());
-    let mut rayon_stable = data.clone();
+    let mut rayon_stable = data.to_vec();
     RayonParallelSliceMut::par_sort(rayon_stable.as_mut_slice());
     assert_eq!(moirai_stable, rayon_stable);
 
-    let mut moirai_unstable = data.clone();
+    let mut moirai_unstable = data.to_vec();
     MoiraiParallelSliceMut::par_sort_unstable(moirai_unstable.as_mut_slice());
-    let mut rayon_unstable = data.clone();
+    let mut rayon_unstable = data.to_vec();
     RayonParallelSliceMut::par_sort_unstable(rayon_unstable.as_mut_slice());
     assert_eq!(moirai_unstable, rayon_unstable);
+}
 
-    // Stable Sorting Group
-    let mut group = c.benchmark_group("parallel_sorting_stable");
+fn bench_group(
+    c: &mut Criterion,
+    group_name: &str,
+    items: usize,
+    data: &[i32],
+    moirai_sort: fn(&mut [i32]),
+    rayon_sort: fn(&mut [i32]),
+) {
+    let mut group = c.benchmark_group(group_name);
     group.sample_size(SAMPLE_SIZE);
-    group.bench_with_input(BenchmarkId::new("moirai", WORK_ITEMS), &data, |b, input| {
+    group.bench_with_input(BenchmarkId::new("moirai", items), &data, |b, input| {
         b.iter_with_setup(
-            || input.clone(),
+            || input.to_vec(),
             |mut v| {
-                MoiraiParallelSliceMut::par_sort(v.as_mut_slice());
+                moirai_sort(v.as_mut_slice());
                 black_box(v);
             },
         )
     });
-    group.bench_with_input(BenchmarkId::new("rayon", WORK_ITEMS), &data, |b, input| {
+    group.bench_with_input(BenchmarkId::new("rayon", items), &data, |b, input| {
         b.iter_with_setup(
-            || input.clone(),
+            || input.to_vec(),
             |mut v| {
-                RayonParallelSliceMut::par_sort(v.as_mut_slice());
+                rayon_sort(v.as_mut_slice());
                 black_box(v);
             },
         )
     });
     group.finish();
+}
 
-    // Unstable Sorting Group
-    let mut group = c.benchmark_group("parallel_sorting_unstable");
-    group.sample_size(SAMPLE_SIZE);
-    group.bench_with_input(BenchmarkId::new("moirai", WORK_ITEMS), &data, |b, input| {
-        b.iter_with_setup(
-            || input.clone(),
-            |mut v| {
-                MoiraiParallelSliceMut::par_sort_unstable(v.as_mut_slice());
-                black_box(v);
-            },
-        )
-    });
-    group.bench_with_input(BenchmarkId::new("rayon", WORK_ITEMS), &data, |b, input| {
-        b.iter_with_setup(
-            || input.clone(),
-            |mut v| {
-                RayonParallelSliceMut::par_sort_unstable(v.as_mut_slice());
-                black_box(v);
-            },
-        )
-    });
-    group.finish();
+fn bench_size(c: &mut Criterion, items: usize, stable_group: &str, unstable_group: &str) {
+    let data = generate_random_data(items);
+    assert_agrees_with_rayon(&data);
+
+    bench_group(
+        c,
+        stable_group,
+        items,
+        &data,
+        MoiraiParallelSliceMut::par_sort,
+        RayonParallelSliceMut::par_sort,
+    );
+    bench_group(
+        c,
+        unstable_group,
+        items,
+        &data,
+        MoiraiParallelSliceMut::par_sort_unstable,
+        RayonParallelSliceMut::par_sort_unstable,
+    );
+}
+
+fn sorting_comparison(c: &mut Criterion) {
+    bench_size(
+        c,
+        WORK_ITEMS,
+        "parallel_sorting_stable",
+        "parallel_sorting_unstable",
+    );
+    bench_size(
+        c,
+        LARGE_ITEMS,
+        "parallel_sorting_stable_large",
+        "parallel_sorting_unstable_large",
+    );
 }
 
 criterion_group! {

--- a/benchmarks/benches/sorting_comparison.rs
+++ b/benchmarks/benches/sorting_comparison.rs
@@ -19,6 +19,8 @@ const WORK_ITEMS: usize = 10_000;
 /// ~250, both far past any worker count, so the row measures how much of the
 /// work tree the runtime actually spreads.
 const LARGE_ITEMS: usize = 4_000_000;
+const LARGE_MEASUREMENT_MILLIS: u64 = 4_000;
+const LARGE_WARM_UP_MILLIS: u64 = 1_000;
 
 fn generate_random_data(items: usize) -> Vec<i32> {
     let mut seed: u64 = 54321;
@@ -60,6 +62,14 @@ fn bench_group(
 ) {
     let mut group = c.benchmark_group(group_name);
     group.sample_size(SAMPLE_SIZE);
+    // A multi-millisecond iteration reaches the sample floor long before the
+    // default window elapses, leaving each sample exposed to whatever else the
+    // host is doing. Measure the large rows for longer so run-to-run spread
+    // stays below the effect being compared.
+    if items >= LARGE_ITEMS {
+        group.measurement_time(Duration::from_millis(LARGE_MEASUREMENT_MILLIS));
+        group.warm_up_time(Duration::from_millis(LARGE_WARM_UP_MILLIS));
+    }
     group.bench_with_input(BenchmarkId::new("moirai", items), &data, |b, input| {
         b.iter_with_setup(
             || input.to_vec(),

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1227,6 +1227,15 @@ execution leaves both halves usable on the caller:
   converted it; the caller panics, matching the pre-existing
   `PoolJoinGuard::wait` assertion and rayon's panic propagation.
 
+Fork granularity is bounded by machine width, not by input size: a sub-slice is
+forked only while it is larger than `len / (workers × 8)`, floored at the
+existing sequential thresholds. Without this the recursion splits to the
+threshold, so leaf count grows with input and every leaf pays for a scope —
+measured below. This is not the deleted budget returning: it is a local,
+static granularity floor with no global counter and no coupling to liveness.
+Deadlock freedom comes from the work-conserving scope; the bound only decides
+when a split stops paying for itself.
+
 `ThreadPool` is *not* deleted here. It remains the `ShuttingDown` fallback for
 the flat executor fan-outs in `cache.rs`, `iter_ops/parallel.rs`, and
 `execution/parallel.rs`, which never nest and therefore never trip the
@@ -1256,8 +1265,11 @@ onto it.
   worker count, not a return to the pool.
 - *Finer work tree.* Removing the budget lets the tree expand to `len/threshold`
   leaves instead of `worker_count - 1` forks, so scheduling overhead per leaf
-  now matters. The thresholds are unchanged in this change and validated by
-  benchmark rather than assumed.
+  now matters. This was measured, not assumed, and it bound: at 4M elements on
+  24 workers the stable sort (~2000 leaves at its 2048 floor) regressed while
+  the unstable sort (~250 leaves at its 16,384 floor) improved. Hence the
+  machine-width granularity bound above; the constant is a measured tuning
+  parameter, and re-tuning it is a benchmark question, not a redesign.
 - *Admission queue pressure.* Per-worker queues hold 256 jobs per priority;
   concurrent deep sorts can reach that. Covered by the caller-lane fallback
   above, which is correctness-preserving but silently sequential — it is not
@@ -1279,9 +1291,30 @@ onto it.
    so it trips nextest's 60 s terminate bound rather than hanging. Deterministic
    worker-count-1 proof stays at the scheduler layer, where ADR-019's nested
    tests own it.
-3. Criterion before/after on a large `par_sort` (input sized past the fork
-   budget's ceiling, where the old cap binds), reported with the stored
+3. Criterion before/after on a large `par_sort`, reported against a stored
    baseline. The parallelism claim is measured, not asserted; a regression
    blocks the change.
 4. `cargo fmt --check`, `clippy --all-targets -D warnings`, `nextest`, and a
    `RUSTDOCFLAGS=-D warnings cargo doc` build for the affected packages.
+
+**Measured outcome.** 24 workers, random `i32`, criterion sample size 10 (4 s
+measurement on the large rows), before and after built and run back to back on
+an otherwise idle host. Rayon's rows, whose code is unchanged, moved +3% to
++11% between the two runs — that spread is the noise floor, and anything inside
+it is reported as no change.
+
+| row | before | after | change |
+| --- | --- | --- | --- |
+| stable, 10 K | 91.5 µs | 57.4 µs | −45.7% |
+| unstable, 10 K | 51.9 µs | 53.3 µs | no change |
+| stable, 4 M | 28.43 ms | 28.06 ms | no change |
+| unstable, 4 M | 33.93 ms | 30.66 ms | −9.8% |
+
+The small-input gain is per-fork cost: a scope replaces an mpsc send plus a
+per-fork completion channel. The large rows are flat to modestly better, which
+is the honest reading of the parallelism claim — 23 outstanding forks already
+filled a 24-worker machine, so lifting the ceiling buys throughput only where
+the tree must expand further than the pool is wide. What this change delivers
+at this size is the removal of the starvation class and its guard rails, not a
+large speedup. `par_sort` remains ~2.5× (stable) and ~4× (unstable) slower than
+rayon on the 4 M rows; that gap predates this change and is its own item.

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1116,3 +1116,172 @@ backpressure, queued cancellation, graceful drain, and shutdown rejection.
 Focused nextest and warning-denied Clippy are the primary evidence tier;
 Criterion compares blocking admission and execution handoff after correctness
 passes. No Tokio or Smol production dependency is introduced.
+
+## ADR-022 (2026-07-25): moirai-iter nested fork-join runs on the scheduler scope
+
+- Status: Accepted [arch] · Refs: ISSUE-219, PRs #97, #98, #99
+
+**Intent.** Decide which runtime executes `moirai-iter`'s *nested* parallel
+work — work whose jobs block on other jobs of the same runtime. Flat,
+non-nesting fan-out is already decided (ADR-019: the indexed executor path);
+this ADR covers the recursive fork-join shape, whose only production caller is
+`parallel/sorting.rs`.
+
+**Context.** `moirai_iter::base::ThreadPool` is an mpsc FIFO queue with a fixed
+worker set and no work stealing. `execute` sends onto a channel; a worker that
+blocks waiting for another job in that pool cannot run it. Its callers
+nevertheless use it as a fork-join runtime: `par_merge_sort_impl` and
+`par_sort_unstable_by_impl` fork one half onto the pool and block on it,
+recursively.
+
+Three defects fixed in isolation are one structural mismatch:
+
+- **#97 (soundness).** `PoolJoinGuard::wait` discarded `recv()` results, so a
+  dead worker was indistinguishable from a completed task;
+  `ZeroCopyParallelIter::map` then `assume_init`-ed memory no worker wrote.
+  Fixed by counting completions and asserting.
+- **#98 (liveness).** The worker loop ran jobs without `catch_unwind`, so a
+  panicking job killed its worker permanently. The pool shrank silently until
+  `execute` queued work nobody could run, surfacing as an unrelated later hang.
+  Fixed by catching the unwind in the worker.
+- **#99 (starvation).** Deep enough recursion blocks every worker on a half that
+  is still queued. Reproduced deterministically: a two-worker pool deadlocked at
+  65,536 elements (≈1M elements on eight cores). Fixed by capping outstanding
+  forks at `worker_count - 1`.
+
+Each fix is a guard rail around the same gap: the pool has no nesting contract.
+The fork budget in particular is a *global* cap — parallelism is bounded by pool
+width rather than by the work tree, and every future blocking caller has to
+remember an unenforced rule. Separately, the pool duplicates a role Moirai
+already owns: `ThreadScheduler` is the work-stealing runtime, and ADR-019 gave
+it a work-conserving nested-wait contract for exactly this shape.
+
+**Constraints.**
+
+1. One work-stealing runtime SSOT (ADR-019/020/021); no second scheduler, and
+   no threads beyond the executor's.
+2. Nested waits must be deadlock-free by construction, not by a caller-side
+   budget rule.
+3. Panic containment and drop safety of `merge`/`MergeGuard` are preserved; a
+   comparator panic still propagates to the caller.
+4. Scheduling refusal (`ShuttingDown`, `ResourceExhausted`) must not silently
+   lose a branch of the work tree — a lost half is an unsorted slice.
+5. No compatibility shim: the superseded path is deleted in the same change.
+6. Regression tests keep the shape where a starvation regression trips
+   nextest's 60 s terminate bound instead of hanging the suite.
+
+**Options.**
+
+*(1) Keep the pool and the guard rails.* Cheapest, already merged, and safe.
+But parallelism stays capped at `worker_count - 1` outstanding forks regardless
+of tree size; the rule is unenforced by types, so every future blocking caller
+re-opens the defect class; and the duplicate runtime keeps attracting the audit
+findings above.
+
+*(2) Give `ThreadPool` work stealing.* Removes the starvation class at the
+source. It also re-implements per-worker deques, stealing, parking, wake
+handshakes, and panic containment — the precise code this audit keeps finding
+defects in, and which `moirai-executor` already has under Loom and Miri
+coverage. Two work-stealing runtimes in one process also over-subscribe cores.
+Rejected as duplication of the scheduler SSOT.
+
+*(3a) Route through `global().for_each_indexed`.* This is what `cache.rs` and
+`iter_ops/parallel.rs` already use, and it never starves — but not because it
+tolerates nesting. `for_each_indexed` *flattens*: when the caller is already a
+scheduler worker or inside an indexed region
+(`get_current_worker_id().is_some() || is_in_indexed_region()`,
+`scheduler/data_parallel.rs`) it runs the whole `0..count` domain inline on the
+current lane. Deliberate — recursively stealing unrelated outer jobs grows the
+worker stack — but it means a recursive divide-and-conquer routed through it
+collapses to sequential below the first level. It is the right primitive for a
+flat index domain and the wrong one for a work tree. It does not solve the
+parallelism ceiling; it lowers it.
+
+*(3b) Route through `ThreadScheduler::scope` (selected).* `scope` is the
+scheduler's fork-join primitive and already carries the property the pool
+lacks: `drain_scope` makes a waiter that is itself a worker run queued work via
+`next_job` instead of parking (ADR-019), so a nested scope cannot remove the
+last runner from the pool. `SchedulerScope::spawn` takes borrowing
+(`'scope`, non-`'static`) closures, and `flush()` is documented for exactly the
+two-lane shape "schedule one branch, run the other on the caller lane". ADR-019
+verified it against a log2-depth recursive fork-join
+(`scheduler_scope_recursive_fork_join_is_sound`).
+
+**Decision.** `moirai-iter`'s recursive fork-join runs on
+`moirai_executor::global().scope::<SyncTask, _>` with `spawn` + `flush` for the
+forked half and caller-lane execution for the other. `sorting.rs` drops
+`ThreadPool`, `PoolJoinGuard`, `SendPtr`, and the fork budget; because scoped
+jobs borrow, the raw-pointer type erasure the pool's `'static` bound forced
+disappears with them. `ForkBudget`/`try_fork`/`end_fork` have no remaining
+caller and are deleted from `base.rs`.
+
+Scheduling refusal is handled at the fork site rather than propagated. The
+scoped closure captures each half by unique borrow, so a job dropped before
+execution leaves both halves usable on the caller:
+
+- `Err(ShuttingDown)` / `Err(ResourceExhausted(_))` — the job was dropped
+  without running and the caller-lane branch had not started, so both halves are
+  sorted on the caller. This is the same admission-backpressure contract
+  `for_each_indexed` already applies (inline execution of a rejected chunk).
+- `Err(SpawnFailed(Panicked))` — the forked half panicked and the scope
+  converted it; the caller panics, matching the pre-existing
+  `PoolJoinGuard::wait` assertion and rayon's panic propagation.
+
+`ThreadPool` is *not* deleted here. It remains the `ShuttingDown` fallback for
+the flat executor fan-outs in `cache.rs`, `iter_ops/parallel.rs`, and
+`execution/parallel.rs`, which never nest and therefore never trip the
+starvation class. Its documented contract narrows to "flat, non-nesting work
+only"; new blocking-on-pool callers are prohibited. Removing it in favour of a
+sequential fallback is filed as a follow-up, since it is a `pub` surface change
+with its own migration.
+
+**Rejected alternative within (3b).** Reusing `moirai_parallel::join_with`,
+which is the same `scope`/`flush`/caller-lane shape. It cannot satisfy
+constraint 4: it takes its branches by value, so a branch whose job is dropped
+on `ResourceExhausted` is unrecoverable, and it `expect`s on the error — a
+queue-full join panics today. Recovering a by-value closure needs a shared
+slot (`Mutex<enum { Pending(F), Done(R) }>`) that the fork site does not, since
+it can capture the halves by unique borrow instead. `join_with`'s admission
+contract is filed as its own defect; when it lands, the sort fork site collapses
+onto it.
+
+**Failure modes.**
+
+- *Helping-recursion stack growth.* A worker helping inside `drain_scope` may
+  run an unrelated job that itself waits and helps, adding frames per nesting
+  level. Bounded here by the sequential thresholds: recursion depth is
+  `log2(len / 2048)` (stable) and `log2(len / 16_384)` (unstable), ≤ ~50 for any
+  addressable slice. This is the risk `for_each_indexed` avoids by flattening;
+  if it becomes load-bearing, the mitigation is a split-count bound derived from
+  worker count, not a return to the pool.
+- *Finer work tree.* Removing the budget lets the tree expand to `len/threshold`
+  leaves instead of `worker_count - 1` forks, so scheduling overhead per leaf
+  now matters. The thresholds are unchanged in this change and validated by
+  benchmark rather than assumed.
+- *Admission queue pressure.* Per-worker queues hold 256 jobs per priority;
+  concurrent deep sorts can reach that. Covered by the caller-lane fallback
+  above, which is correctness-preserving but silently sequential — it is not
+  surfaced through a counter the way
+  `ThreadScheduler::admission_caller_runs` surfaces the indexed path. Recorded
+  as residual risk.
+- *Global-executor coupling.* `par_sort` now depends on the process-wide
+  executor rather than a private pool, so its parallelism follows executor
+  configuration and its shutdown state. Intended (it is the point of one
+  runtime), but it removes the ability to size a pool per sort in tests.
+
+**Verification plan.**
+
+1. Value-semantic sort tests (existing ordering, stability, by-key, duplicate,
+   empty/single, panic/drop-count cases) stay green unchanged.
+2. Starvation regression: a sort deep enough to exceed any plausible worker
+   count, plus a sort invoked from *inside* a scheduler worker (nested through
+   `for_each_indexed`), both asserting ordering. A regression cannot complete,
+   so it trips nextest's 60 s terminate bound rather than hanging. Deterministic
+   worker-count-1 proof stays at the scheduler layer, where ADR-019's nested
+   tests own it.
+3. Criterion before/after on a large `par_sort` (input sized past the fork
+   budget's ceiling, where the old cap binds), reported with the stored
+   baseline. The parallelism claim is measured, not asserted; a regression
+   blocks the change.
+4. `cargo fmt --check`, `clippy --all-targets -D warnings`, `nextest`, and a
+   `RUSTDOCFLAGS=-D warnings cargo doc` build for the affected packages.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -284,6 +284,39 @@ architecture definition.
 - **Status**: Completed 2026-07-16.
 - **ADR**: `docs/adr/0019-tree-dup-002-dual-channel-consolidation.md`
   (Accepted).
+#### ✅ ISSUE-219 [arch]: Run `moirai-iter` nested fork-join on the scheduler scope
+- **Type**: Runtime Architecture / Concurrency Correctness
+- **Root Cause**: `moirai_iter::base::ThreadPool` is a FIFO queue with no work
+  stealing, so a worker blocked on another of its jobs cannot run it, yet
+  `par_sort` recursed through exactly that shape. PRs #97 (completion counting
+  after a `MaybeUninit` soundness hole), #98 (worker survival past a job panic),
+  and #99 (fork budget against deterministic starvation at 65,536 elements on
+  two workers) are three guard rails around one missing nesting contract; the
+  budget additionally capped the work tree at the pool's width.
+- **Resolution**: The fork runs on `HybridExecutor::scope`, whose waiter runs
+  queued work instead of parking (ADR-019). Deleted `ForkBudget`/`try_fork`/
+  `end_fork` and the sort's `SendPtr`/`PoolJoinGuard` raw-pointer erasure —
+  scoped jobs borrow. A refused fork (`ShuttingDown`, `ResourceExhausted`) runs
+  on the caller rather than being lost. Fork granularity is now bounded by
+  machine width (`len / (workers × 8)`, floored at the sequential thresholds)
+  because leaf-per-threshold splitting made scope overhead dominate. `ThreadPool`
+  narrows to flat, non-nesting fallback use.
+- **Acceptance criteria**: deep recursion and worker-nested sorts complete and
+  order their slices (a regression cannot complete, so it trips nextest's
+  terminate bound); a shut-down executor still sorts through the refusal arm;
+  no benchmark regression on a large `par_sort`.
+- **Evidence tier**: type/analysis (ADR-019's deadlock-freedom argument now
+  covers this caller) + empirical (`moirai-iter` 194/194, paired Criterion
+  before/after: −45.7% stable 10 K, −9.8% unstable 4 M, no change on the
+  remaining rows against a +3–11% noise floor).
+- **ADR**: `docs/adr.md` ADR-022 (Accepted).
+- **Follow-ups**: `moirai_parallel::join_with` panics on a refused fork instead
+  of running it on the caller (its by-value branches are unrecoverable — needs
+  a slot); `ThreadPool` removal in favour of sequential fallbacks in `cache.rs`,
+  `iter_ops/parallel.rs`, and `execution/parallel.rs`; the sort's caller-lane
+  fallback is not surfaced through a counter the way
+  `ThreadScheduler::admission_caller_runs` surfaces the indexed path.
+
 #### 🔄 ISSUE-208 [arch]: Make `ThreadScheduler::scope` sound under nesting (unblock parallel non-indexed `drive`)
 - **Type**: Scheduler Correctness / Memory Safety
 - **Root Cause**: `SchedulerScopeState::wait` (`schedule/runtime/types.rs`) spins

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -102,6 +102,10 @@ remain hidden behind stale counters.
     closeout and merged as `9b3caa5`. `recurseml/analysis` errored on both
     heads, while CodeRabbit passed on the PM-only head; local gates remain the
     executor acceptance evidence.
+- [x] [arch] ISSUE-219: Move `moirai-iter`'s recursive sort fork-join off the
+  non-stealing `ThreadPool` onto `HybridExecutor::scope`, delete the fork budget
+  and the sort's raw-pointer erasure, run a refused fork on the caller, and
+  bound fork granularity by machine width against paired Criterion evidence.
 - [x] [patch] ISSUE-214: Serialize `ShardedResourcePool::clear` against
   recycle/take mutations without adding a single contended hot-path lock.
 - [x] [patch] ISSUE-217: Remove the executor's hidden index-count grain floor so

--- a/moirai-iter/src/base.rs
+++ b/moirai-iter/src/base.rs
@@ -288,42 +288,17 @@ pub fn get_shared_thread_pool() -> Arc<ThreadPool> {
 }
 
 /// Simple thread pool implementation.
-/// This is a lightweight alternative to external crates like rayon.
+///
+/// Flat fan-out only: jobs must not block on other jobs of this pool. The pool
+/// is a FIFO queue over a fixed worker set with no work stealing, so a worker
+/// waiting for a queued job cannot run it, and once every worker waits that way
+/// the queue stalls permanently. Nested and recursive fork-join belongs on the
+/// scheduler scope instead, whose waiters run queued work while they wait
+/// (ADR-022).
 pub struct ThreadPool {
     /// Wrapped in Option so `Drop` can close the channel before joining workers.
     sender: Option<std::sync::mpsc::Sender<ErasedThreadJob>>,
     workers: Vec<std::thread::JoinHandle<()>>,
-    /// Permits for callers that block a worker while awaiting another job here.
-    fork_budget: ForkBudget,
-}
-
-/// Remaining permits to block a worker on another job in the same pool.
-///
-/// The pool does not steal work, so a worker blocked waiting for a queued job
-/// cannot help run it. If every worker blocks that way the queue stalls
-/// permanently. Holding the outstanding count below the worker count keeps one
-/// worker free to drain it, which is what guarantees progress.
-///
-/// The budget belongs to the pool rather than to a caller: the shared pool is a
-/// process-wide singleton, so two callers each keeping their own count could
-/// together block every worker even while each stayed under the limit alone.
-pub(crate) type ForkBudget = Arc<std::sync::atomic::AtomicUsize>;
-
-/// Claim a permit to block a worker, or report that the caller must proceed
-/// without forking.
-pub(crate) fn try_fork(budget: &ForkBudget) -> bool {
-    budget
-        .fetch_update(
-            std::sync::atomic::Ordering::AcqRel,
-            std::sync::atomic::Ordering::Acquire,
-            |remaining| remaining.checked_sub(1),
-        )
-        .is_ok()
-}
-
-/// Return a permit once the awaited job has been joined.
-pub(crate) fn end_fork(budget: &ForkBudget) {
-    budget.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
 }
 
 /// Heap-stable thread-pool job with monomorphized run/drop functions.
@@ -445,26 +420,15 @@ impl ThreadPool {
             })
             .collect();
 
-        let fork_budget = Arc::new(std::sync::atomic::AtomicUsize::new(
-            workers.len().saturating_sub(1),
-        ));
-
         Self {
             sender: Some(sender),
             workers,
-            fork_budget,
         }
     }
 
     /// Number of worker threads, always at least one.
     pub fn worker_count(&self) -> usize {
         self.workers.len()
-    }
-
-    /// This pool's shared budget for callers that block a worker on another of
-    /// its jobs. See [`ForkBudget`].
-    pub(crate) fn fork_budget(&self) -> &ForkBudget {
-        &self.fork_budget
     }
 
     pub fn execute<F>(&self, job: F)

--- a/moirai-iter/src/parallel/sorting.rs
+++ b/moirai-iter/src/parallel/sorting.rs
@@ -1,10 +1,8 @@
 //! Parallel slice sorting implementation.
 
-use crate::base::{
-    end_fork, get_shared_thread_pool, try_fork, ForkBudget, PoolJoinGuard, SendPtr, ThreadPool,
-};
+use moirai_core::error::ExecutorError;
+use moirai_executor::{global, HybridExecutor, SyncTask};
 use std::mem::MaybeUninit;
-use std::sync::Arc;
 
 /// Extension trait for parallel slice sorting.
 pub trait ParallelSliceMut<T: Send> {
@@ -53,8 +51,7 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
     where
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
-        let pool = get_shared_thread_pool();
-        par_merge_sort_impl(self, &compare, &pool, pool.fork_budget());
+        par_merge_sort_impl(global(), self, &compare);
     }
 
     fn par_sort_by_key<K, F>(&mut self, f: F)
@@ -76,8 +73,7 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
     where
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
-        let pool = get_shared_thread_pool();
-        par_sort_unstable_by_impl(self, &compare, &pool, pool.fork_budget());
+        par_sort_unstable_by_impl(global(), self, &compare);
     }
 
     fn par_sort_unstable_by_key<K, F>(&mut self, f: F)
@@ -127,12 +123,69 @@ where
     j
 }
 
-fn par_sort_unstable_by_impl<T, F>(
-    slice: &mut [T],
+/// Sort both halves concurrently: one on a scheduler lane, the other on the
+/// caller's.
+///
+/// The scheduler's scope is the fork-join primitive here rather than a plain
+/// thread pool because a worker that waits inside a scope *runs queued work*
+/// instead of parking (ADR-019). A pool without that property starves the
+/// moment recursion blocks every worker on a half that is still queued, which
+/// is what the deleted fork budget existed to prevent — at the cost of capping
+/// the whole work tree at the pool's width. Scoped jobs also borrow, so the
+/// halves cross the lane boundary as ordinary `&mut [T]` rather than as raw
+/// pointers laundered through a `'static` bound.
+///
+/// Each half is captured by unique borrow, never moved, so a job the scheduler
+/// refuses can still be run here: on refusal neither half has been touched.
+///
+/// The executor is a parameter rather than `global()` so the refusal path can
+/// be exercised against a shut-down executor in tests.
+///
+/// # Panics
+///
+/// Panics if the scheduled half panicked, propagating the failure on the
+/// caller's thread as rayon does.
+fn fork_join_halves<T, F, S>(
+    executor: &HybridExecutor,
+    left: &mut [T],
+    right: &mut [T],
     compare: &F,
-    pool: &Arc<ThreadPool>,
-    budget: &ForkBudget,
+    sort: S,
 ) where
+    T: Send,
+    F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
+    S: Fn(&HybridExecutor, &mut [T], &F) + Copy + Send + Sync,
+{
+    // The job below *reborrows* its half rather than moving it: passing a
+    // `&mut` where a `&mut` is expected is an implicit reborrow, so the borrow
+    // ends when the scope joins and both bindings are usable again afterwards.
+    // That is what lets the refusal arm run a half the scheduler never ran.
+    let forked = executor.scope::<SyncTask, _>(|scope| {
+        scope.spawn(|_| sort(executor, left, compare))?;
+        // Enter the scheduler before the caller takes its own half, so the two
+        // halves overlap instead of running back to back.
+        scope.flush()?;
+        sort(executor, right, compare);
+        Ok(())
+    });
+
+    match forked {
+        Ok(()) => {}
+        // The scheduler refused the job and dropped it unexecuted, so `flush`
+        // returned before the caller's half started: neither half has run and
+        // both are still owned here. `ShuttingDown` and a full admission queue
+        // are the two ways that happens; running the work on the caller is the
+        // same answer `for_each_indexed` gives a rejected chunk.
+        Err(ExecutorError::ShuttingDown | ExecutorError::ResourceExhausted(_)) => {
+            sort(executor, left, compare);
+            sort(executor, right, compare);
+        }
+        Err(error) => panic!("invariant: scheduled sort half failed ({error})"),
+    }
+}
+
+fn par_sort_unstable_by_impl<T, F>(executor: &HybridExecutor, slice: &mut [T], compare: &F)
+where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
 {
@@ -150,46 +203,11 @@ fn par_sort_unstable_by_impl<T, F>(
         &mut right[1..] // Skip the pivot itself
     };
 
-    if !try_fork(budget) {
-        // Budget spent — see `ForkBudget`. Both sides run here so no worker
-        // blocks on a half that nothing is left to schedule.
-        par_sort_unstable_by_impl(left, compare, pool, budget);
-        par_sort_unstable_by_impl(right, compare, pool, budget);
-        return;
-    }
-
-    // Erase types to () to satisfy the 'static requirements of ThreadPool::execute
-    let left_ptr = SendPtr(left.as_mut_ptr() as *mut ());
-    let left_len = left.len();
-    let compare_ptr = SendPtr(compare as *const F as *mut F as *mut ());
-
-    let (tx, rx) = std::sync::mpsc::channel();
-    let pool_clone = Arc::clone(pool);
-    let budget_clone = Arc::clone(budget);
-    let guard = PoolJoinGuard::new(rx, 1);
-
-    pool.execute(move || {
-        let left_ptr = left_ptr;
-        let compare_ptr = compare_ptr;
-        unsafe {
-            let left_slice = std::slice::from_raw_parts_mut(left_ptr.as_ptr() as *mut T, left_len);
-            let compare_ref = &*(compare_ptr.as_ptr() as *const F);
-            par_sort_unstable_by_impl(left_slice, compare_ref, &pool_clone, &budget_clone);
-        }
-        let _ = tx.send(());
-    });
-
-    par_sort_unstable_by_impl(right, compare, pool, budget);
-    guard.wait();
-    end_fork(budget);
+    fork_join_halves(executor, left, right, compare, par_sort_unstable_by_impl);
 }
 
-fn par_merge_sort_impl<T, F>(
-    slice: &mut [T],
-    compare: &F,
-    pool: &Arc<ThreadPool>,
-    budget: &ForkBudget,
-) where
+fn par_merge_sort_impl<T, F>(executor: &HybridExecutor, slice: &mut [T], compare: &F)
+where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
 {
@@ -200,66 +218,12 @@ fn par_merge_sort_impl<T, F>(
     }
 
     let mid = len / 2;
-    let (left, right) = slice.split_at_mut(mid);
-
-    if try_fork(budget) {
-        // Erase types to () to satisfy the 'static requirements of ThreadPool::execute
-        let left_ptr = SendPtr(left.as_mut_ptr() as *mut ());
-        let left_len = left.len();
-        let compare_ptr = SendPtr(compare as *const F as *mut F as *mut ());
-
-        let (tx, rx) = std::sync::mpsc::channel();
-        let pool_clone = Arc::clone(pool);
-        let guard = PoolJoinGuard::new(rx, 1);
-
-        pub_execute_merge::<T, F>(
-            pool,
-            tx,
-            left_ptr,
-            left_len,
-            compare_ptr,
-            pool_clone,
-            Arc::clone(budget),
-        );
-
-        par_merge_sort_impl(right, compare, pool, budget);
-        guard.wait();
-        end_fork(budget);
-    } else {
-        // The pool is already carrying as many blocked halves as it can while
-        // still guaranteeing progress; sort both halves here instead.
-        par_merge_sort_impl(left, compare, pool, budget);
-        par_merge_sort_impl(right, compare, pool, budget);
+    {
+        let (left, right) = slice.split_at_mut(mid);
+        fork_join_halves(executor, left, right, compare, par_merge_sort_impl);
     }
 
     merge(slice, mid, compare);
-}
-
-// Helper to keep closures distinct
-#[allow(clippy::too_many_arguments)]
-fn pub_execute_merge<T, F>(
-    pool: &ThreadPool,
-    tx: std::sync::mpsc::Sender<()>,
-    left_ptr: SendPtr<()>,
-    left_len: usize,
-    compare_ptr: SendPtr<()>,
-    pool_clone: Arc<ThreadPool>,
-    budget: ForkBudget,
-) where
-    T: Send,
-    F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
-{
-    pool.execute(move || {
-        let left_ptr = left_ptr;
-        let compare_ptr = compare_ptr;
-        let pool_clone = pool_clone;
-        unsafe {
-            let left_slice = std::slice::from_raw_parts_mut(left_ptr.as_ptr() as *mut T, left_len);
-            let compare_ref = &*(compare_ptr.as_ptr() as *const F);
-            par_merge_sort_impl(left_slice, compare_ref, &pool_clone, &budget);
-        }
-        let _ = tx.send(());
-    });
 }
 
 struct MergeGuard<'a, T> {
@@ -351,56 +315,101 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    // Regression: the recursion forks one half onto the pool and blocks on it,
-    // so a forked half that forks again ties up a worker while depending on
-    // another. The pool does not steal work, so once every worker was blocked
-    // that way the queued halves had nobody left to run them and the sort never
-    // returned. Reproduced here with a two-worker pool and an input deep enough
-    // to fork five times; before the fork budget this hung until the harness
-    // killed it.
+    // Recursion depth well past any worker count. Under a runtime whose waiters
+    // park instead of helping, the forked halves have nobody left to run them
+    // and the sort never returns, so a regression trips nextest's terminate
+    // bound rather than failing an assertion. The deterministic single-worker
+    // proof lives at the scheduler layer, where the scope contract is owned
+    // (ADR-019); this input is what the sort itself can constrain, since it
+    // runs on the process-wide executor.
     #[test]
-    fn deep_recursion_completes_on_a_pool_smaller_than_its_depth() {
-        let pool = Arc::new(ThreadPool::new(2));
+    fn deep_recursion_completes() {
+        let mut data: Vec<u64> = (0..1_048_576u64).rev().collect();
+        par_merge_sort_impl(global(), &mut data, &u64::cmp);
+
+        assert!(
+            data.windows(2).all(|pair| pair[0] <= pair[1]),
+            "the sort must both finish and order the slice"
+        );
+    }
+
+    #[test]
+    fn deep_unstable_recursion_completes() {
+        let mut data: Vec<u64> = (0..1_048_576u64).rev().collect();
+        par_sort_unstable_by_impl(global(), &mut data, &u64::cmp);
+
+        assert!(
+            data.windows(2).all(|pair| pair[0] <= pair[1]),
+            "the sort must both finish and order the slice"
+        );
+    }
+
+    // A scheduler that refuses the forked half must not lose it. Sorting
+    // against a shut-down executor makes every fork take the refusal arm, so
+    // the whole recursion falls back to the caller's lane: slower, still
+    // correct. A refusal arm that dropped the half instead would leave the
+    // slice unsorted at every level.
+    #[test]
+    fn refused_forks_run_on_the_caller() {
+        let mut executor =
+            moirai_executor::HybridExecutor::new(moirai_core::executor::ExecutorConfig {
+                worker_threads: 2,
+                ..moirai_core::executor::ExecutorConfig::default()
+            })
+            .expect("build a local executor");
+        executor.shutdown().expect("shut the local executor down");
+        assert!(
+            executor.scope::<SyncTask, _>(|_| Ok(())).is_err(),
+            "precondition: the executor must refuse scopes, or the sorts below \
+             never reach the refusal arm"
+        );
+
+        let mut data: Vec<u64> = (0..16_384u64).rev().collect();
+        par_merge_sort_impl(&executor, &mut data, &u64::cmp);
+        assert!(
+            data.windows(2).all(|pair| pair[0] <= pair[1]),
+            "a refused fork must still sort its half on the caller"
+        );
+
         let mut data: Vec<u64> = (0..65_536u64).rev().collect();
-        par_merge_sort_impl(&mut data, &u64::cmp, &pool, pool.fork_budget());
-
+        par_sort_unstable_by_impl(&executor, &mut data, &u64::cmp);
         assert!(
             data.windows(2).all(|pair| pair[0] <= pair[1]),
-            "the sort must both finish and order the slice"
+            "a refused fork must still sort its half on the caller"
         );
     }
 
+    // Sorts entered from *inside* a scheduler worker: the nested case, where a
+    // waiter that parks removes the last runner from the pool. Several of them
+    // run at once so the workers are saturated before any of them forks.
     #[test]
-    fn deep_unstable_recursion_completes_on_a_small_pool() {
-        let pool = Arc::new(ThreadPool::new(2));
-        let mut data: Vec<u64> = (0..262_144u64).rev().collect();
-        par_sort_unstable_by_impl(&mut data, &u64::cmp, &pool, pool.fork_budget());
+    fn nested_sorts_complete_from_scheduler_workers() {
+        const SORTS: usize = 8;
 
-        assert!(
-            data.windows(2).all(|pair| pair[0] <= pair[1]),
-            "the sort must both finish and order the slice"
-        );
-    }
+        let mut inputs: Vec<Vec<u64>> =
+            (0..SORTS).map(|_| (0..65_536u64).rev().collect()).collect();
 
-    // The budget belongs to the pool, not to a sort: the shared pool is a
-    // process-wide singleton, so two sorts each holding their own count could
-    // together block every worker while each stayed under the limit alone.
-    // Both of these run deep enough to fork, against a pool too small for even
-    // one of them unbudgeted.
-    #[test]
-    fn concurrent_sorts_share_one_pool_budget() {
-        let pool = Arc::new(ThreadPool::new(2));
+        let slots: Vec<crate::base::SendPtr<Vec<u64>>> = inputs
+            .iter_mut()
+            .map(|input| crate::base::SendPtr(input as *mut Vec<u64>))
+            .collect();
 
-        std::thread::scope(|scope| {
-            for _ in 0..2 {
-                let pool = Arc::clone(&pool);
-                scope.spawn(move || {
-                    let mut data: Vec<u64> = (0..65_536u64).rev().collect();
-                    par_merge_sort_impl(&mut data, &u64::cmp, &pool, pool.fork_budget());
-                    assert!(data.windows(2).all(|pair| pair[0] <= pair[1]));
-                });
-            }
-        });
+        moirai_executor::global()
+            .for_each_indexed::<SyncTask, _>(SORTS, |index| {
+                // Safety: each index owns exactly one element of `inputs`, and
+                // `for_each_indexed` joins every invocation before returning,
+                // so the borrows are disjoint and end before `inputs` is read.
+                let data = unsafe { &mut *slots[index].as_ptr() };
+                par_merge_sort_impl(global(), data.as_mut_slice(), &u64::cmp);
+            })
+            .expect("nested sort fan-out must complete");
+
+        for input in &inputs {
+            assert!(
+                input.windows(2).all(|pair| pair[0] <= pair[1]),
+                "every nested sort must both finish and order its slice"
+            );
+        }
     }
 
     #[test]

--- a/moirai-iter/src/parallel/sorting.rs
+++ b/moirai-iter/src/parallel/sorting.rs
@@ -51,7 +51,9 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
     where
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
-        par_merge_sort_impl(global(), self, &compare);
+        let executor = global();
+        let grain = fork_grain(executor, self.len(), STABLE_SEQUENTIAL_THRESHOLD);
+        par_merge_sort_impl(executor, self, &compare, grain);
     }
 
     fn par_sort_by_key<K, F>(&mut self, f: F)
@@ -73,7 +75,9 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
     where
         F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
     {
-        par_sort_unstable_by_impl(global(), self, &compare);
+        let executor = global();
+        let grain = fork_grain(executor, self.len(), UNSTABLE_SEQUENTIAL_THRESHOLD);
+        par_sort_unstable_by_impl(executor, self, &compare, grain);
     }
 
     fn par_sort_unstable_by_key<K, F>(&mut self, f: F)
@@ -89,6 +93,23 @@ impl<T: Send> ParallelSliceMut<T> for [T] {
 // task scheduling and merge/partition overhead.
 const STABLE_SEQUENTIAL_THRESHOLD: usize = 2048;
 const UNSTABLE_SEQUENTIAL_THRESHOLD: usize = 16_384;
+
+/// Segments per worker the recursion aims for before it stops forking.
+///
+/// The thresholds above are an absolute floor, not a granularity policy: on a
+/// large input they leave a leaf count proportional to `len`, and every leaf
+/// costs a scope — measurably more than the sort work it enables once the leaf
+/// is small relative to the machine. Oversubscribing the workers by this factor
+/// keeps enough independent segments for stealing to balance an uneven split
+/// (a straggler delays the phase by at most one segment) while making the fork
+/// count a function of machine width rather than input size.
+const SEGMENTS_PER_WORKER: usize = 8;
+
+/// Smallest sub-slice still worth handing to another lane.
+fn fork_grain(executor: &HybridExecutor, len: usize, sequential_threshold: usize) -> usize {
+    let workers = executor.config().worker_threads.max(1);
+    sequential_threshold.max(len.div_ceil(workers.saturating_mul(SEGMENTS_PER_WORKER)))
+}
 
 fn partition<T, F>(v: &mut [T], compare: &F) -> usize
 where
@@ -150,22 +171,23 @@ fn fork_join_halves<T, F, S>(
     left: &mut [T],
     right: &mut [T],
     compare: &F,
+    grain: usize,
     sort: S,
 ) where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
-    S: Fn(&HybridExecutor, &mut [T], &F) + Copy + Send + Sync,
+    S: Fn(&HybridExecutor, &mut [T], &F, usize) + Copy + Send + Sync,
 {
     // The job below *reborrows* its half rather than moving it: passing a
     // `&mut` where a `&mut` is expected is an implicit reborrow, so the borrow
     // ends when the scope joins and both bindings are usable again afterwards.
     // That is what lets the refusal arm run a half the scheduler never ran.
     let forked = executor.scope::<SyncTask, _>(|scope| {
-        scope.spawn(|_| sort(executor, left, compare))?;
+        scope.spawn(|_| sort(executor, left, compare, grain))?;
         // Enter the scheduler before the caller takes its own half, so the two
         // halves overlap instead of running back to back.
         scope.flush()?;
-        sort(executor, right, compare);
+        sort(executor, right, compare, grain);
         Ok(())
     });
 
@@ -177,20 +199,24 @@ fn fork_join_halves<T, F, S>(
         // are the two ways that happens; running the work on the caller is the
         // same answer `for_each_indexed` gives a rejected chunk.
         Err(ExecutorError::ShuttingDown | ExecutorError::ResourceExhausted(_)) => {
-            sort(executor, left, compare);
-            sort(executor, right, compare);
+            sort(executor, left, compare, grain);
+            sort(executor, right, compare, grain);
         }
         Err(error) => panic!("invariant: scheduled sort half failed ({error})"),
     }
 }
 
-fn par_sort_unstable_by_impl<T, F>(executor: &HybridExecutor, slice: &mut [T], compare: &F)
-where
+fn par_sort_unstable_by_impl<T, F>(
+    executor: &HybridExecutor,
+    slice: &mut [T],
+    compare: &F,
+    grain: usize,
+) where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
 {
     let len = slice.len();
-    if len <= UNSTABLE_SEQUENTIAL_THRESHOLD {
+    if len <= grain {
         slice.sort_unstable_by(compare);
         return;
     }
@@ -203,16 +229,23 @@ where
         &mut right[1..] // Skip the pivot itself
     };
 
-    fork_join_halves(executor, left, right, compare, par_sort_unstable_by_impl);
+    fork_join_halves(
+        executor,
+        left,
+        right,
+        compare,
+        grain,
+        par_sort_unstable_by_impl,
+    );
 }
 
-fn par_merge_sort_impl<T, F>(executor: &HybridExecutor, slice: &mut [T], compare: &F)
+fn par_merge_sort_impl<T, F>(executor: &HybridExecutor, slice: &mut [T], compare: &F, grain: usize)
 where
     T: Send,
     F: Fn(&T, &T) -> std::cmp::Ordering + Sync + Send,
 {
     let len = slice.len();
-    if len <= STABLE_SEQUENTIAL_THRESHOLD {
+    if len <= grain {
         slice.sort_by(compare);
         return;
     }
@@ -220,7 +253,7 @@ where
     let mid = len / 2;
     {
         let (left, right) = slice.split_at_mut(mid);
-        fork_join_halves(executor, left, right, compare, par_merge_sort_impl);
+        fork_join_halves(executor, left, right, compare, grain, par_merge_sort_impl);
     }
 
     merge(slice, mid, compare);
@@ -325,7 +358,8 @@ mod tests {
     #[test]
     fn deep_recursion_completes() {
         let mut data: Vec<u64> = (0..1_048_576u64).rev().collect();
-        par_merge_sort_impl(global(), &mut data, &u64::cmp);
+        let grain = fork_grain(global(), data.len(), STABLE_SEQUENTIAL_THRESHOLD);
+        par_merge_sort_impl(global(), &mut data, &u64::cmp, grain);
 
         assert!(
             data.windows(2).all(|pair| pair[0] <= pair[1]),
@@ -336,7 +370,8 @@ mod tests {
     #[test]
     fn deep_unstable_recursion_completes() {
         let mut data: Vec<u64> = (0..1_048_576u64).rev().collect();
-        par_sort_unstable_by_impl(global(), &mut data, &u64::cmp);
+        let grain = fork_grain(global(), data.len(), UNSTABLE_SEQUENTIAL_THRESHOLD);
+        par_sort_unstable_by_impl(global(), &mut data, &u64::cmp, grain);
 
         assert!(
             data.windows(2).all(|pair| pair[0] <= pair[1]),
@@ -365,14 +400,19 @@ mod tests {
         );
 
         let mut data: Vec<u64> = (0..16_384u64).rev().collect();
-        par_merge_sort_impl(&executor, &mut data, &u64::cmp);
+        par_merge_sort_impl(&executor, &mut data, &u64::cmp, STABLE_SEQUENTIAL_THRESHOLD);
         assert!(
             data.windows(2).all(|pair| pair[0] <= pair[1]),
             "a refused fork must still sort its half on the caller"
         );
 
         let mut data: Vec<u64> = (0..65_536u64).rev().collect();
-        par_sort_unstable_by_impl(&executor, &mut data, &u64::cmp);
+        par_sort_unstable_by_impl(
+            &executor,
+            &mut data,
+            &u64::cmp,
+            UNSTABLE_SEQUENTIAL_THRESHOLD,
+        );
         assert!(
             data.windows(2).all(|pair| pair[0] <= pair[1]),
             "a refused fork must still sort its half on the caller"
@@ -400,7 +440,12 @@ mod tests {
                 // `for_each_indexed` joins every invocation before returning,
                 // so the borrows are disjoint and end before `inputs` is read.
                 let data = unsafe { &mut *slots[index].as_ptr() };
-                par_merge_sort_impl(global(), data.as_mut_slice(), &u64::cmp);
+                par_merge_sort_impl(
+                    global(),
+                    data.as_mut_slice(),
+                    &u64::cmp,
+                    STABLE_SEQUENTIAL_THRESHOLD,
+                );
             })
             .expect("nested sort fan-out must complete");
 


### PR DESCRIPTION
Decides — and then implements — how `moirai-iter` runs nested/blocking parallel
work. ADR-022 in `docs/adr.md`.

## Why

`crate::base::ThreadPool` is a FIFO mpsc queue over a fixed worker set with no
work stealing, but `par_sort` uses it as a fork-join runtime: it forks one half
onto the pool and blocks on it, recursively. The three defects fixed in #97
(discarded `recv()` results → `assume_init` over unwritten memory), #98 (a
panicking job killing its worker permanently) and #99 (deterministic starvation
at 65,536 elements on two workers) are three guard rails around one missing
nesting contract. The fork budget from #99 additionally capped the work tree at
the pool's width.

## What

The scheduler already has the contract the pool lacks: a worker waiting inside
`scope` runs queued work instead of parking (ADR-019, verified there against a
log2-depth recursive fork-join). The sort's fork moves there.

Options weighed in the ADR: keep the guard rails; add work stealing to
`ThreadPool`; route through `for_each_indexed`; route through `scope`. The
`for_each_indexed` option is the interesting rejection — it never starves, but
only because it *flattens*: a nested indexed region runs its whole domain
inline on the current lane, so a recursive divide-and-conquer routed through it
collapses to sequential below the first level.

Consequences:

- `ForkBudget`/`try_fork`/`end_fork` deleted; `SendPtr`/`PoolJoinGuard`
  erasure gone from `sorting.rs` — scoped jobs borrow, so the halves cross the
  lane boundary as ordinary `&mut [T]`.
- A refused fork (`ShuttingDown`, `ResourceExhausted`) runs on the caller
  rather than being lost — the same answer `for_each_indexed` gives a rejected
  chunk. Each half is reborrowed rather than moved, which is what makes that
  recoverable.
- Fork granularity is bounded by machine width (`len / (workers × 8)`, floored
  at the sequential thresholds). Not the budget returning: a local static
  granularity floor, no global counter, no coupling to liveness. It is here
  because the benchmark demanded it — see below.
- `ThreadPool` narrows to flat, non-nesting fallback use; its removal is filed.

## Evidence

`moirai-iter` 194/194, plus `moirai-executor`/`moirai-parallel`/`moirai`
336/336. Regressions keep the shape where a starvation regression cannot
complete, so it trips nextest's terminate bound rather than hanging:
`deep_recursion_completes`, `deep_unstable_recursion_completes`,
`nested_sorts_complete_from_scheduler_workers` (sorts entered from *inside*
scheduler workers), and `refused_forks_run_on_the_caller` (sorts against a
shut-down executor, with a precondition assert that it really refuses).

Paired Criterion, 24 workers, before and after built and run back to back on an
idle host. Rayon's unchanged rows moved +3–11% between runs; that is the noise
floor.

| row | before | after | change |
| --- | --- | --- | --- |
| stable, 10 K | 91.5 µs | 57.4 µs | −45.7% |
| unstable, 10 K | 51.9 µs | 53.3 µs | no change |
| stable, 4 M | 28.43 ms | 28.06 ms | no change |
| unstable, 4 M | 33.93 ms | 30.66 ms | −9.8% |

The first cut, without the granularity bound, regressed the stable 4 M row 21%
and 45% across two runs — leaf count grew with input size and every leaf paid
for a scope. That is what the bound fixes.

Read the large rows honestly: 23 outstanding forks already filled a 24-worker
machine, so lifting the ceiling buys throughput only where the tree must expand
further than the pool is wide. What lands here is the removed starvation class,
not a large speedup. `par_sort` remains ~2.5×/~4× slower than rayon at 4 M;
that gap predates this change.

`cargo fmt --check`, `clippy -p moirai-iter -p moirai-benchmarks --all-targets
-D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc -p moirai-iter`, doctests, and
the `--benches` smoke run are clean. One unrelated commit gates a
`result-diagnostics` constant that was failing the benchmarks clippy gate on
dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a fundamental concurrency defect in `moirai-iter`'s parallel sorting by migrating nested fork-join operations from a non-work-stealing `ThreadPool` (which could deadlock when recursion blocked all workers) to the scheduler's `scope` primitive that runs queued work while waiting. The change removes the fork budget mechanism and raw pointer type erasure, enables refused forks to execute on the caller's lane, and adds a machine-width-based granularity bound to prevent per-leaf scope overhead from dominating at large inputs. The migration eliminates three related starvation bugs (#97, #98, #99) and delivers up to 45.7% speedup on small inputs while maintaining correctness on deeply recursive sorts.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/adr.md` |
| 2 | `docs/backlog.md` |
| 3 | `docs/checklist.md` |
| 4 | `moirai-iter/src/base.rs` |
| 5 | `moirai-iter/src/parallel/sorting.rs` |
| 6 | `benchmarks/benches/sorting_comparison.rs` |
| 7 | `benchmarks/benches/result_handle_diagnostics/types.rs` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `benchmarks/benches/result_handle_diagnostics/types.rs` | This file adds a feature gate to an unrelated constant in result diagnostics benchmarks, which has no connection to the sorting/fork-join runtime changes that are the focus of this PR |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->