### PR TITLE
Document the split deque's initialization invariant

### DIFF
--- a/moirai-scheduler/src/deque/split.rs
+++ b/moirai-scheduler/src/deque/split.rs
@@ -1,3 +1,40 @@
+//! Split work-stealing deque: a private owner stack over a shared deque.
+//!
+//! The owner pushes and pops against an in-line `PrivateStack` that thieves
+//! cannot see, and only spills to the shared [`ChaseLevDeque`] when that stack
+//! fills. Most owner traffic therefore costs no atomics at all, and the shared
+//! deque carries only the work old enough to be worth stealing.
+//!
+//! # Which end each operation takes
+//!
+//! `push` and `pop` work the newest end of the private stack, while the spill
+//! hands over the *oldest* half — so an owner keeps the freshest work, where its
+//! cache is warm, and thieves get the coldest, where contention is least. `pop`
+//! falls through to the shared deque only once the private stack is empty.
+//!
+//! # Initialization invariant
+//!
+//! `PrivateStack` stores `[MaybeUninit<T>; N]` with a `len`, and the invariant
+//! is that exactly `items[0..len]` are initialized. Every unsafe access here is
+//! justified by that one statement: `pop` reads at `len - 1` after decrementing,
+//! `Drop` drops precisely the live prefix, and the spill reads `items[0..count]`
+//! having checked `count <= len`.
+//!
+//! Keeping the invariant true across a panic is what [`OffloadGuard`] is for.
+//! The spill moves items out of the front one at a time and pushes each onto the
+//! shared deque, so between iterations the prefix `items[0..moved]` is already
+//! moved out while `items[moved..len]` is still live — a state no plain `len`
+//! can describe. If a push unwinds there, the guard's `Drop` shifts the live
+//! remainder down over the vacated slots and shortens `len` to match, restoring
+//! the invariant before any other code observes the stack. That also matters for
+//! the poison-tolerant `Mutex` below: `unwrap_or_else(into_inner)` continues
+//! after a panic, and it can only do so safely because the guard has already
+//! repaired the state by the time the lock is released.
+//!
+//! The guard's normal path and its panic path converge on the same shift, which
+//! is why a panic in the *last* push — where `moved` has reached `count` — is
+//! handled correctly by the branch nominally labelled "no panic".
+
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::sync::Mutex;
@@ -48,6 +85,9 @@ impl<T, const N: usize> PrivateStack<T, N> {
         }
 
         self.len -= 1;
+        // SAFETY: `len` was non-zero and has just been decremented, so it now
+        // indexes the topmost live element. Reading it out leaves `items[0..len]`
+        // initialized, which is the invariant.
         Some(unsafe { self.items[self.len].assume_init_read() })
     }
 
@@ -64,6 +104,9 @@ impl<T, const N: usize> PrivateStack<T, N> {
         };
 
         for i in 0..count {
+            // SAFETY: `i < count <= len / 2 <= len`, so this slot is live. The
+            // read leaves it moved-out, which `guard.moved` records; the guard's
+            // `Drop` reconciles that with `len` whether or not `push` unwinds.
             let item = unsafe { guard.stack.items[i].assume_init_read() };
             guard.moved += 1;
             shared.push(item);
@@ -84,6 +127,11 @@ impl<'a, T, const N: usize> Drop for OffloadGuard<'a, T, N> {
             // Shift the remaining initialized elements to the front of the stack.
             let remaining_to_move = self.count - self.moved;
             let retained = self.stack.len - self.count;
+            // SAFETY: `items[moved..len]` are still initialized — the loop only
+            // moved out the first `moved`. Shifting that whole live range down
+            // to index 0 spans `(count - moved) + (len - count) == len - moved`
+            // elements, all within `N`. `copy` is a memmove, so the overlap
+            // between source and destination is fine.
             unsafe {
                 std::ptr::copy(
                     self.stack.items.as_ptr().add(self.moved),
@@ -96,6 +144,10 @@ impl<'a, T, const N: usize> Drop for OffloadGuard<'a, T, N> {
             // Normal execution: all `count` elements successfully offloaded.
             let retained = self.stack.len - self.count;
             if retained > 0 {
+                // SAFETY: every one of the first `count` slots was moved out, so
+                // the live elements are `items[count..len]`; shifting those
+                // `retained` down to index 0 stays in bounds, and `copy`
+                // tolerates the overlap.
                 unsafe {
                     std::ptr::copy(
                         self.stack.items.as_ptr().add(self.count),
@@ -112,6 +164,9 @@ impl<'a, T, const N: usize> Drop for OffloadGuard<'a, T, N> {
 impl<T, const N: usize> Drop for PrivateStack<T, N> {
     fn drop(&mut self) {
         for item in self.items.iter_mut().take(self.len) {
+            // SAFETY: `items[0..len]` are exactly the initialized elements, and
+            // each is dropped once here. Slots past `len` were either never
+            // written or already moved out by `pop`/the spill.
             unsafe {
                 item.assume_init_drop();
             }
@@ -192,6 +247,57 @@ mod tests {
         fn drop(&mut self) {
             self.0.fetch_add(1, Ordering::Relaxed);
         }
+    }
+
+    #[test]
+    fn pop_drains_the_shared_deque_once_the_private_stack_empties() {
+        // `pop` falls through to the shared side only when the private stack is
+        // exhausted. The existing offload test always drains the shared deque by
+        // stealing first, so that fall-through never returns a value there.
+        let deque: SplitDeque<i32, 4> = SplitDeque::new();
+
+        for value in 1..=5 {
+            deque.push(value);
+        }
+        // The fifth push spilled the oldest half — 1 and 2 — leaving 3, 4, 5.
+
+        assert_eq!(deque.pop(), Some(5));
+        assert_eq!(deque.pop(), Some(4));
+        assert_eq!(deque.pop(), Some(3));
+
+        // Private side is empty now, so the rest must come from the shared deque
+        // rather than reporting the queue as drained.
+        let spilled = [deque.pop(), deque.pop()];
+        assert!(
+            spilled.iter().all(Option::is_some),
+            "both spilled items must still be reachable through pop, got {spilled:?}"
+        );
+        let mut spilled: Vec<i32> = spilled.into_iter().flatten().collect();
+        spilled.sort_unstable();
+        assert_eq!(spilled, vec![1, 2]);
+
+        assert_eq!(deque.pop(), None);
+        assert!(deque.is_empty());
+    }
+
+    #[test]
+    fn spilled_items_are_dropped_exactly_once() {
+        // The spill moves items between two owners of very different kinds; a
+        // slot counted by both — or by neither — shows up here and nowhere else.
+        let drops = Arc::new(AtomicUsize::new(0));
+        {
+            let deque: SplitDeque<DropProbe, 4> = SplitDeque::new();
+            for _ in 0..5 {
+                deque.push(DropProbe(drops.clone()));
+            }
+            assert_eq!(drops.load(Ordering::Relaxed), 0, "nothing dropped yet");
+        }
+
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            5,
+            "every item must be dropped once, whether it ended up private or spilled"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Thirteenth increment of the moirai audit — `moirai-scheduler/src/deque/split.rs`, six unsafe sites with one comment between them. It is the owner-side companion to the Chase-Lev deque documented in #87.

## Audit result: sound

`PrivateStack` holds `[MaybeUninit<T>; N]` alongside a `len`, and every unsafe access in the file rests on a single statement that was nowhere written down: exactly `items[0..len]` are initialized.

The subtle part is `OffloadGuard`. The spill moves items out of the front one at a time and pushes each onto the shared deque, so between iterations the stack sits in a state no single `len` can describe — `items[0..moved]` moved out, `items[moved..len]` still live. If a push unwinds there, the guard's `Drop` shifts the live remainder down over the vacated slots and shortens `len` to match.

Three things I checked rather than assumed:

- **The boundary case.** When the *last* push panics, `moved` has already reached `count`, so control takes the branch labelled "normal execution". That branch computes the identical shift, so the mislabelled path is still correct.
- **Overlap.** `ptr::copy` is a memmove, so shifting a live range down over itself is fine.
- **Capacity.** `push` cannot exceed `N`: a spill leaves `ceil(len / 2)`, which is below `N` for the `N >= 2` that `new` asserts.

The guard is also what makes the poison-tolerant lock defensible. `push` and `pop` continue through a poisoned mutex with `unwrap_or_else(into_inner)`, and that is only sound because the guard repaired the state before the lock was released — a connection worth recording, since the two pieces of code are far apart and neither mentions the other.

## Coverage: two paths nothing reached

- **`pop`'s fall-through to the shared deque never returned a value.** `test_split_deque_threshold_offloading` drains the shared side via `steal()` before popping, so the fall-through only ever produced `None`.
- **Nothing checked that spilled items are dropped exactly once.** That is the property that would break first if the guard's accounting were wrong, since a miscount leaves an item owned by both sides or by neither — a leak or a double drop, neither of which the existing tests could see.

## Verification

- `cargo fmt -p moirai-scheduler -- --check` ✓
- `cargo clippy -p moirai-scheduler --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-scheduler` — 25/25 ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-scheduler` ✓

Audit progress: thirteen moirai files — seven sound, six with defects found and fixed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR documents the initialization invariant for the split deque's private stack and adds comprehensive safety comments to all unsafe code blocks. It establishes that `PrivateStack` maintains the invariant that exactly `items[0..len]` are initialized, which justifies every unsafe operation in the file. The documentation explains how `OffloadGuard` preserves this invariant across panics during spills, and clarifies the connection between the guard's cleanup logic and the poison-tolerant mutex behavior. Two new tests are added to cover previously untested code paths: popping from the shared deque after the private stack empties, and verifying that spilled items are dropped exactly once.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-scheduler/src/deque/split.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->