### PR TITLE
fix(parallel): Run a refused join branch on the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Run a `moirai_parallel::join_with` branch on the caller when the scheduler
+  refuses it. The scheduled branch was moved into the job, so a job refused
+  while shutting down — or rejected by a full per-worker admission queue — was
+  dropped with the branch inside it, and the join turned the resulting error
+  into a panic. Both lanes now claim the branch from a shared slot, so it runs
+  exactly once on whichever lane reaches it, and backpressure makes a join
+  sequential rather than fatal.
+
 ### Changed
 
 - Run the `moirai-iter` parallel sorts' recursive fork-join on the unified

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1251,8 +1251,12 @@ on `ResourceExhausted` is unrecoverable, and it `expect`s on the error — a
 queue-full join panics today. Recovering a by-value closure needs a shared
 slot (`Mutex<enum { Pending(F), Done(R) }>`) that the fork site does not, since
 it can capture the halves by unique borrow instead. `join_with`'s admission
-contract is filed as its own defect; when it lands, the sort fork site collapses
-onto it.
+contract was filed as its own defect and has since landed (ISSUE-220) with
+exactly that shared slot. Collapsing the sort fork site onto it is therefore
+possible but not automatic: the slot costs an uncontended mutex per fork that
+the reborrowing form does not, and the sort forks far more often than a
+top-level `join`. That collapse is a measured decision, deferred to a
+benchmark rather than assumed here.
 
 **Failure modes.**
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -310,12 +310,52 @@ architecture definition.
   before/after: −45.7% stable 10 K, −9.8% unstable 4 M, no change on the
   remaining rows against a +3–11% noise floor).
 - **ADR**: `docs/adr.md` ADR-022 (Accepted).
-- **Follow-ups**: `moirai_parallel::join_with` panics on a refused fork instead
-  of running it on the caller (its by-value branches are unrecoverable — needs
-  a slot); `ThreadPool` removal in favour of sequential fallbacks in `cache.rs`,
+- **Follow-ups**: `join_with`'s refused-fork panic (ISSUE-220, done);
+  `ThreadPool` removal in favour of sequential fallbacks in `cache.rs`,
   `iter_ops/parallel.rs`, and `execution/parallel.rs`; the sort's caller-lane
   fallback is not surfaced through a counter the way
   `ThreadScheduler::admission_caller_runs` surfaces the indexed path.
+
+#### ✅ ISSUE-220 [patch]: Run a refused `join_with` branch on the caller
+- **Type**: Concurrency Correctness / API Contract
+- **Root Cause**: `join_with` moved its left branch into the scoped job. A job
+  the scheduler refuses — `ShuttingDown`, or `ResourceExhausted` from a full
+  per-worker admission queue — is dropped before it runs, taking the branch
+  with it, and the resulting scope error met an `expect`. Bounded admission
+  (ISSUE-212) therefore turned a valid join into a panic under backpressure,
+  the same class ISSUE-219 fixed in the sorts. `for_each_indexed` already had
+  the right contract: run a rejected chunk inline.
+- **Resolution**: The scheduled branch lives in a `Mutex<Branch<F, R>>` that
+  both lanes share and claim from, so the caller can run a branch the scheduler
+  never did. The caller-local branch keeps the same state machine without a
+  lock. The refusal arm re-claims both; the claim makes that idempotent.
+  `join_on` takes the executor by parameter so the path is testable.
+- **Acceptance criteria**: a join against a shut-down executor returns both
+  branch values and runs each branch exactly once; a healthy-executor join runs
+  each branch exactly once across repeated rounds where either lane may win the
+  claim; no regression on the `join_sum_pair` benchmark rows.
+- **Evidence tier**: type/analysis (the claim is a single `mem::replace`, so
+  exactly one lane can observe `Pending`) + empirical (`moirai-parallel` 34/34,
+  paired Criterion on `join_sum_pair`).
+- **Residual**: `moirai_parallel::scope` has the same defect for its N buffered
+  jobs and cannot use this slot — a refused `flush` drops the whole batch and
+  the caller cannot tell which jobs ran. The systemic fix is in the executor:
+  have `SchedulerScope::flush` execute a rejected job inline like
+  `for_each_indexed` does, which needs `schedule_job` to hand the job back
+  rather than drop it. Filed as ISSUE-221.
+
+#### ⏳ ISSUE-221 [patch]: Execute a rejected scoped job inline instead of dropping it
+- **Type**: Scheduler Correctness
+- **Root Cause**: `ThreadScheduler::schedule_job` drops a job the admission
+  queue rejects and returns `ResourceExhausted`. `SchedulerScope::flush` cannot
+  recover it, so every `scope` caller loses that job's work; only
+  `for_each_indexed`, which owns its index domain, can reconstruct it.
+  `moirai_parallel::scope` panics through `expect` in that case.
+- **Acceptance criteria**: `flush` runs a rejected job on the caller under the
+  same panic boundary as a worker, records `admission_caller_run`, and a
+  saturated-admission scope test observes every spawned job running exactly
+  once.
+- **Dependencies**: a `schedule_job` variant that returns the rejected job.
 
 #### 🔄 ISSUE-208 [arch]: Make `ThreadScheduler::scope` sound under nesting (unblock parallel non-indexed `drive`)
 - **Type**: Scheduler Correctness / Memory Safety

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -102,6 +102,12 @@ remain hidden behind stale counters.
     closeout and merged as `9b3caa5`. `recurseml/analysis` errored on both
     heads, while CodeRabbit passed on the PM-only head; local gates remain the
     executor acceptance evidence.
+- [x] [patch] ISSUE-220: Give `join_with`'s scheduled branch a claimable slot so
+  a refused fork runs on the caller instead of panicking, with exactly-once
+  coverage for both the refusal arm and the healthy two-lane race.
+- [ ] [patch] ISSUE-221: Execute a rejected scoped job inline in
+  `SchedulerScope::flush` rather than dropping it, so every `scope` caller —
+  `moirai_parallel::scope` included — survives admission backpressure.
 - [x] [arch] ISSUE-219: Move `moirai-iter`'s recursive sort fork-join off the
   non-stealing `ThreadPool` onto `HybridExecutor::scope`, delete the fork budget
   and the sort's raw-pointer erasure, run a refused fork on the caller, and

--- a/moirai-parallel/src/ops.rs
+++ b/moirai-parallel/src/ops.rs
@@ -27,8 +27,90 @@
 
 use super::DisjointMutPtr;
 use crate::policy::{ExecutionPolicy, Parallel};
-use moirai_core::error::ExecutorResult;
-use moirai_executor::{global, SchedulerScope, SyncTask};
+use moirai_core::error::{ExecutorError, ExecutorResult};
+use moirai_executor::{global, HybridExecutor, SchedulerScope, SyncTask};
+use std::sync::Mutex;
+
+/// State of the scheduled branch of a join.
+///
+/// The scheduler can refuse a job — while shutting down, or when a worker's
+/// bounded admission queue is full — and it drops the refused job before
+/// returning the error. A branch owned by that job would go with it, so the
+/// closure lives here instead and whichever lane reaches it first takes it.
+/// The caller can therefore still run a branch the scheduler never did.
+enum Branch<F, R> {
+    /// Nobody has claimed this branch yet.
+    Pending(F),
+    /// A lane claimed the branch and has not published a result. Observing
+    /// this once the scope has joined means that lane unwound.
+    Claimed,
+    /// Ran to completion.
+    Done(R),
+}
+
+impl<F, R> Branch<F, R>
+where
+    F: FnOnce() -> R,
+{
+    /// Take the closure if this lane is the one that gets to run it.
+    fn claim(&mut self) -> Option<F> {
+        match std::mem::replace(self, Self::Claimed) {
+            Self::Pending(branch) => Some(branch),
+            other => {
+                *self = other;
+                None
+            }
+        }
+    }
+
+    fn complete(&mut self, result: R) {
+        *self = Self::Done(result);
+    }
+
+    /// Run the branch on a lane that shares the slot, unless another lane
+    /// already claimed it.
+    ///
+    /// The lock is released before the closure runs, so a branch never holds it
+    /// across arbitrary caller code and a panicking branch cannot poison it.
+    fn run_shared(slot: &Mutex<Self>) {
+        let Some(branch) = lock(slot).claim() else {
+            return;
+        };
+        let result = branch();
+        lock(slot).complete(result);
+    }
+
+    /// Run a branch that never leaves this thread.
+    fn run_here(&mut self) {
+        let Some(branch) = self.claim() else {
+            return;
+        };
+        let result = branch();
+        self.complete(result);
+    }
+
+    /// Take the finished value.
+    fn into_result(self) -> R {
+        match self {
+            Self::Done(result) => result,
+            _ => panic!("invariant: a join branch neither ran nor reported failure"),
+        }
+    }
+}
+
+/// Lock without propagating poisoning: every path that touches a slot leaves
+/// it in a consistent state, and [`Branch::run_shared`] never holds the lock
+/// across the branch closure, so a poisoned flag carries no information here.
+fn lock<T>(slot: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    slot.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Reclaim a slot once every lane that shared it has finished.
+fn lock_owned<T>(slot: Mutex<T>) -> T {
+    slot.into_inner()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
 
 /// Run two closures to completion and return both results.
 ///
@@ -37,6 +119,14 @@ use moirai_executor::{global, SchedulerScope, SyncTask};
 /// caller, [`Parallel`] schedules the left closure on the unified scheduler and
 /// runs the right closure on the caller lane, and [`crate::Adaptive`] currently
 /// stays sequential for a fixed two-branch join.
+///
+/// A branch the scheduler refuses runs on the caller instead, so a shutting-down
+/// or saturated executor makes the join sequential rather than losing a branch.
+///
+/// # Panics
+///
+/// Panics if a branch panicked, propagating the failure on the caller's thread
+/// as rayon does.
 pub fn join_with<P, A, B, RA, RB>(left: A, right: B) -> (RA, RB)
 where
     P: ExecutionPolicy,
@@ -48,22 +138,49 @@ where
         return (left(), right());
     }
 
-    let mut left_result = None;
-    let mut right_result = None;
-    global()
-        .scope::<SyncTask, _>(|scope| {
-            scope.spawn(|_| {
-                left_result = Some(left());
-            })?;
-            scope.flush()?;
-            right_result = Some(right());
-            Ok(())
-        })
-        .expect("moirai global executor: join_with");
+    join_on(global(), left, right)
+}
+
+/// [`join_with`]'s parallel path against a named executor.
+///
+/// Separate from the public entry so the refusal path can be exercised against
+/// a shut-down executor in tests.
+pub(crate) fn join_on<A, B, RA, RB>(executor: &HybridExecutor, left: A, right: B) -> (RA, RB)
+where
+    A: FnOnce() -> RA + Send,
+    B: FnOnce() -> RB,
+    RA: Send,
+{
+    // Only the left branch crosses a lane boundary, so only it needs a shared
+    // slot. The right branch stays on this thread and is reborrowed by the
+    // scope body, which leaves it runnable here if the body returns early.
+    let left_slot = Mutex::new(Branch::Pending(left));
+    let mut right_slot = Branch::Pending(right);
+
+    let forked = executor.scope::<SyncTask, _>(|scope| {
+        scope.spawn(|_| Branch::run_shared(&left_slot))?;
+        // Enter the scheduler before the caller takes its own branch, so the
+        // two overlap instead of running back to back.
+        scope.flush()?;
+        right_slot.run_here();
+        Ok(())
+    });
+
+    match forked {
+        Ok(()) => {}
+        // The scheduler refused the job and dropped it unexecuted, so neither
+        // branch is guaranteed to have run. Both claims are idempotent: a
+        // branch that did run is no longer `Pending`.
+        Err(ExecutorError::ShuttingDown | ExecutorError::ResourceExhausted(_)) => {
+            Branch::run_shared(&left_slot);
+            right_slot.run_here();
+        }
+        Err(error) => panic!("invariant: scheduled join branch failed ({error})"),
+    }
 
     (
-        left_result.expect("scoped join left branch must complete"),
-        right_result.expect("scoped join right branch must complete"),
+        lock_owned(left_slot).into_result(),
+        right_slot.into_result(),
     )
 }
 

--- a/moirai-parallel/src/tests.rs
+++ b/moirai-parallel/src/tests.rs
@@ -514,3 +514,76 @@ proptest::proptest! {
         proptest::prop_assert_eq!(par, seq);
     }
 }
+
+// A scheduler that refuses the scheduled branch must not lose it. Joining
+// against a shut-down executor makes every fork take the refusal arm, so both
+// branches run on the caller: sequential, still complete. Before this, the
+// refused branch was dropped with its job and `join_with` panicked through
+// `expect` — a queue-full executor turned a valid join into a crash.
+#[test]
+fn refused_join_branches_run_on_the_caller() {
+    let mut executor =
+        moirai_executor::HybridExecutor::new(moirai_core::executor::ExecutorConfig {
+            worker_threads: 2,
+            ..moirai_core::executor::ExecutorConfig::default()
+        })
+        .expect("build a local executor");
+    executor.shutdown().expect("shut the local executor down");
+    assert!(
+        executor
+            .scope::<moirai_executor::SyncTask, _>(|_| Ok(()))
+            .is_err(),
+        "precondition: the executor must refuse scopes, or the join below never \
+         reaches the refusal arm"
+    );
+
+    let left = [1u64, 2, 3, 4];
+    let right = [10u64, 20, 30];
+    let left_ran = AtomicUsize::new(0);
+    let right_ran = AtomicUsize::new(0);
+
+    let (left_sum, right_sum) = crate::ops::join_on(
+        &executor,
+        || {
+            left_ran.fetch_add(1, Ordering::Relaxed);
+            left.iter().sum::<u64>()
+        },
+        || {
+            right_ran.fetch_add(1, Ordering::Relaxed);
+            right.iter().sum::<u64>()
+        },
+    );
+
+    assert_eq!(left_sum, 10);
+    assert_eq!(right_sum, 60);
+    // Exactly once each: the slot claim is what stops a branch running on both
+    // the scheduler lane and the caller.
+    assert_eq!(left_ran.load(Ordering::Relaxed), 1);
+    assert_eq!(right_ran.load(Ordering::Relaxed), 1);
+}
+
+// The claim is a two-lane race, not just a fallback: a branch must run exactly
+// once whether the scheduler took it or the caller did. Repeated so both
+// outcomes are reachable on a healthy executor.
+#[test]
+fn join_runs_each_branch_exactly_once() {
+    const ROUNDS: usize = 256;
+
+    for _ in 0..ROUNDS {
+        let left_ran = AtomicUsize::new(0);
+        let right_ran = AtomicUsize::new(0);
+
+        let (left, right) = join_with::<Parallel, _, _, _, _>(
+            || left_ran.fetch_add(1, Ordering::Relaxed),
+            || right_ran.fetch_add(1, Ordering::Relaxed),
+        );
+
+        assert_eq!(
+            (left, right),
+            (0, 0),
+            "each branch observes a fresh counter"
+        );
+        assert_eq!(left_ran.load(Ordering::Relaxed), 1);
+        assert_eq!(right_ran.load(Ordering::Relaxed), 1);
+    }
+}


### PR DESCRIPTION
Follow-up filed by ADR-022. `moirai_parallel::join_with` moved its left branch
*into* the scoped job, so a job the scheduler refused was dropped with the
branch inside it — and the resulting scope error met an `expect`.

Two ways that happens today, both reachable:

- `ShuttingDown` — the scope returns before the body runs at all.
- `ResourceExhausted` — a worker's admission queue is bounded at 256 per
  priority (ISSUE-212), and `schedule_job` drops the rejected job.

So bounded admission turned a valid join into a **panic** under backpressure
rather than a slowdown. `for_each_indexed` already had the right contract for
the same condition: run the rejected chunk inline.

## Change

The scheduled branch lives in a `Mutex<Branch<F, R>>` that both lanes share:

```
Pending(F) --claim--> Claimed --complete--> Done(R)
```

`claim` is a single `mem::replace`, so exactly one lane can observe `Pending`
and the caller's refusal arm is idempotent — it re-claims both branches without
needing to know how far the scope got. The caller-local right branch uses the
same state machine without a lock (it never crosses a lane). `Claimed` surviving
a joined scope means that lane unwound, which is the panic path.

`join_on` takes the executor by parameter so the refusal path is testable;
`join_with` passes `global()`. Public signature and bounds are unchanged.

## Evidence

`moirai-parallel` 34/34, and 341/341 across parallel/iter/executor/moirai.

- `refused_join_branches_run_on_the_caller` — joins against a shut-down
  executor (with a precondition assert that it really refuses), asserting both
  values *and* that each branch ran exactly once.
- `join_runs_each_branch_exactly_once` — 256 rounds on a healthy executor,
  where either lane may win the claim.

Paired Criterion on `join_sum_pair`, built and run back to back on an idle
host. The `sequential` row does not reach the changed code and still moved
−5.4%, so that is the noise floor; the moirai rows are inside it:

| row | before | after | change |
| --- | --- | --- | --- |
| moirai, 100 K | 22.73 µs | 21.75 µs | −4.3% (noise) |
| moirai, 1 M | 216.6 µs | 204.6 µs | −4.6% (noise) |
| sequential, 1 M (unchanged code) | 322.9 µs | 309.1 µs | −5.4% |

The uncontended mutex costs nothing measurable.

`cargo fmt --check`, `clippy -p moirai-parallel --all-targets -D warnings`,
`RUSTDOCFLAGS=-D warnings cargo doc`, doctests, and a workspace
`cargo check --all-targets` are clean.

## What this does *not* fix

`moirai_parallel::scope` has the same defect for its N buffered jobs, and this
slot cannot reach it: a refused `flush` drops the whole batch and the caller
cannot tell which jobs ran. The systemic fix belongs in the executor — have
`SchedulerScope::flush` execute a rejected job inline like `for_each_indexed`
does, which requires `schedule_job` to hand the job back rather than drop it.
Filed as ISSUE-221 with that dependency.

ADR-022's claim that the sort fork site would collapse onto `join_with` once
this landed is corrected in the same commit: it is now *possible*, but the slot
costs a mutex per fork that the sort's reborrowing form avoids, and the sort
forks far more often than a top-level join. That collapse is a measured
decision, not an automatic one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug in `moirai_parallel::join_with` where a branch scheduled on the executor could be dropped and lost if the scheduler refused the job (either during shutdown or when admission queues were full), causing the join to panic instead of gracefully degrading to sequential execution. The fix introduces a shared state machine using `Mutex<Branch<F, R>>` that allows either the scheduler lane or the caller lane to claim and execute each branch exactly once. When the scheduler refuses a job, the caller can now reclaim and execute the branch inline, making the join sequential but complete rather than fatal. The implementation ensures exactly-once execution semantics through atomic claim operations and includes comprehensive tests for both the refusal path and the healthy two-lane race condition.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-parallel/src/tests.rs` |
| 2 | `moirai-parallel/src/ops.rs` |
| 3 | `CHANGELOG.md` |
| 4 | `docs/backlog.md` |
| 5 | `docs/adr.md` |
| 6 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->