### PR TITLE
Check the inline job fit in release builds too

### DIFF
--- a/moirai-executor/src/schedule/job/mod.rs
+++ b/moirai-executor/src/schedule/job/mod.rs
@@ -74,7 +74,20 @@ impl InlineJob {
     where
         F: FnOnce(usize) + Send,
     {
-        debug_assert!(inline_job_fits::<F>());
+        // Checked in release too, not just under `debug_assert`: this is a safe
+        // function whose precondition is UB-critical, since an `F` too large for
+        // the storage would be written past it, and a debug-only guard
+        // disappears exactly where the consequence stops being a panic.
+        //
+        // It costs nothing. Both operands are compile-time constants, so for a
+        // type that fits this folds to `assert!(true)` and leaves no code.
+        //
+        // A `const` assertion cannot be used here even though the operands are
+        // constant: `ScheduledJob::new` picks between the inline and boxed forms
+        // at runtime, and the inline branch is still *instantiated* for an
+        // oversized closure it never takes. Asserting at compile time therefore
+        // rejects the boxed path's own callers.
+        assert!(inline_job_fits::<F>());
         let mut job = Self {
             storage: InlineJobStorage::new(),
             execute: execute_inline::<F>,
@@ -123,7 +136,7 @@ impl InlineJobStorage {
     }
 }
 
-fn inline_job_fits<F>() -> bool {
+const fn inline_job_fits<F>() -> bool {
     size_of::<F>() <= size_of::<InlineJobStorage>() && align_of::<F>() <= align_of::<InlineJob>()
 }
 


### PR DESCRIPTION
Fourteenth increment of the moirai audit — `moirai-executor/src/schedule/job/mod.rs`, the small-buffer optimization that stores worker closures inline and falls back to boxing. Eleven unsafe sites.

## Audit result: sound

This is the best-built file the audit has reached, so most of the value here is recording *why* it is correct.

**The fit check's asymmetry is deliberate, not the classic bug.** It tests size against `InlineJobStorage` but alignment against the enclosing `InlineJob`:

```rust
size_of::<F>() <= size_of::<InlineJobStorage>() && align_of::<F>() <= align_of::<InlineJob>()
```

That reads exactly like size-checked-but-not-alignment. It isn't. `InlineJob` is `#[repr(C, align(64))]` with `storage` as its first field, so the storage address carries the full cache-line alignment. Testing the storage type's own 8-byte alignment would have been the actual mistake — it would box closures that fit perfectly well.

**Execution is single-shot by construction.** `execute` swaps `drop` to `drop_consumed` *before* invoking, so a closure consumed inside `catch_unwind` cannot be dropped a second time on the panic path.

## Change: check the fit in release too

`InlineJob::new` is a **safe** function whose precondition is UB-critical — an oversized `F` is written past the storage — and it was guarded only by `debug_assert!`. The guard therefore vanished in precisely the builds where violating it stops being a panic and becomes memory corruption. Both call sites gate correctly today, so nothing was broken; this closes the gap between the invariant and its enforcement.

`assert!` costs nothing here. Both operands are compile-time constants, so for a type that fits it folds to `assert!(true)` and emits no code.

## Why not a `const` assertion

That was my first attempt, and it is wrong — worth recording so it is not retried.

`ScheduledJob::new` picks between the inline and boxed representations **at runtime**:

```rust
if inline_job_fits::<F>() { InlineJob::new(task) }       // dead for oversized F...
else { InlineJob::new(boxed_job(task)) }                 // ...but still instantiated
```

The inline branch is never *taken* for an oversized closure, but it is still *monomorphized*, so a compile-time assertion rejects the boxed path's own callers. Building the probe made this concrete: the assertion fired twice — once for my deliberate misuse, and once for the existing `oversized_job_uses_boxed_inline_trampoline` test, which is entirely legitimate.

Compile-time assertions are structurally incompatible with runtime representation dispatch. The comment at the site now says so.

One methodological note, since it nearly produced the opposite conclusion: the first falsification ran under `cargo check` and reported no error. `check` performs no codegen, and a `const` block depending on a generic parameter is only evaluated at monomorphization, so that probe could not have failed either way. Verifying a property with a tool that cannot observe it is worse than not verifying it, because the result looks like evidence.

## Verification

- `cargo fmt -p moirai-executor -- --check` ✓
- `cargo clippy -p moirai-executor --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-executor` — 89/89 ✓, including the oversized-boxed test the `const` form rejected
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-executor` ✓
- `cargo build -p moirai-executor --release` ✓

Audit progress: fourteen moirai files — eight sound, six with defects found and fixed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR strengthens safety guarantees in the inline job storage optimization by upgrading the size-and-alignment fit check from `debug_assert!` to `assert!` in the `InlineJob::new` function. The change ensures that an oversized closure cannot be written past the storage buffer in release builds, preventing potential memory corruption. The assert has zero runtime cost since both operands are compile-time constants that fold to `assert!(true)` for types that fit. The PR also documents why a `const` assertion would be incorrect here: the runtime dispatch between inline and boxed representations still instantiates the inline branch for oversized closures, causing compile-time assertions to reject legitimate boxed-path callers.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-executor/src/schedule/job/mod.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation when creating inline jobs so invalid configurations are rejected in all builds, including release builds.
  * Enabled compile-time evaluation of inline job size and alignment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->