### PR TITLE
fix(executor): Run a scope job the admission queue rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Run a scoped job on the calling lane when the scheduler's admission queue
+  rejects it. `SchedulerScope::flush` previously dropped such a job and
+  returned the error, so a scope broke its "every spawned job runs before the
+  scope returns" promise silently — the dropped job's completion token
+  decrements the scope counter exactly as a finished one does, so the caller
+  resumed as though borrowed work had happened, and `moirai_parallel::scope`
+  turned the error into a panic. Admission now leaves a refused job in the
+  caller's slot, and the caller-run event is counted through the existing
+  `admission_caller_runs` surface. Shutdown is not backpressure and still
+  propagates.
 - Run a `moirai_parallel::join_with` branch on the caller when the scheduler
   refuses it. The scheduled branch was moved into the job, so a job refused
   while shutting down — or rejected by a full per-worker admission queue — was

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -344,18 +344,40 @@ architecture definition.
   `for_each_indexed` does, which needs `schedule_job` to hand the job back
   rather than drop it. Filed as ISSUE-221.
 
-#### ⏳ ISSUE-221 [patch]: Execute a rejected scoped job inline instead of dropping it
+#### ✅ ISSUE-221 [patch]: Execute a rejected scoped job inline instead of dropping it
 - **Type**: Scheduler Correctness
 - **Root Cause**: `ThreadScheduler::schedule_job` drops a job the admission
   queue rejects and returns `ResourceExhausted`. `SchedulerScope::flush` cannot
   recover it, so every `scope` caller loses that job's work; only
   `for_each_indexed`, which owns its index domain, can reconstruct it.
-  `moirai_parallel::scope` panics through `expect` in that case.
+  `moirai_parallel::scope` panics through `expect` in that case. The loss is
+  invisible to the scope's own counters: a dropped job's completion token
+  decrements the pending count exactly as a finished one does, so the caller
+  resumes as though borrowed work had happened.
+- **Resolution**: `admit_job` takes the job in an `&mut Option` slot the caller
+  owns and leaves it there when admission refuses it — the shape the blocking
+  queue's `try_push` already used. `flush` runs what is left behind on its own
+  lane through the job's existing unwind boundary and counts it with
+  `record_admission_caller_run`. `schedule_chunk` collapses onto
+  `schedule_single`. Shutdown is not backpressure and still propagates.
+  `caller_lane_id` names the calling lane as `worker_count()`, documented on
+  `SchedulerScope::spawn` as a lane identity rather than a worker index.
 - **Acceptance criteria**: `flush` runs a rejected job on the caller under the
   same panic boundary as a worker, records `admission_caller_run`, and a
   saturated-admission scope test observes every spawned job running exactly
   once.
-- **Dependencies**: a `schedule_job` variant that returns the rejected job.
+- **Evidence tier**: empirical, red→green — both new tests fail against the
+  parent revision (jobs never run; a caller-run panic surfaces as
+  `ResourceExhausted` rather than `SpawnFailed`) and pass with the fix.
+  `moirai-executor` 91/91 and 343/343 across executor/parallel/iter/moirai.
+- **Residual**: the fix is verified at the scheduler layer, where admission can
+  be saturated deterministically on a one-worker scheduler. `moirai_parallel::
+  scope` inherits it through the same `flush`, but has no test of its own —
+  saturating the process-wide executor from that layer would be a fragile test.
+  A refused job now runs on the caller's thread, which for a non-worker caller
+  is a thread the job's closure was not written for; the lane identity in its
+  `usize` argument is documented, but a closure that assumed a worker lane is
+  a caller-side contract change.
 
 #### 🔄 ISSUE-208 [arch]: Make `ThreadScheduler::scope` sound under nesting (unblock parallel non-indexed `drive`)
 - **Type**: Scheduler Correctness / Memory Safety

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -105,7 +105,7 @@ remain hidden behind stale counters.
 - [x] [patch] ISSUE-220: Give `join_with`'s scheduled branch a claimable slot so
   a refused fork runs on the caller instead of panicking, with exactly-once
   coverage for both the refusal arm and the healthy two-lane race.
-- [ ] [patch] ISSUE-221: Execute a rejected scoped job inline in
+- [x] [patch] ISSUE-221: Execute a rejected scoped job inline in
   `SchedulerScope::flush` rather than dropping it, so every `scope` caller —
   `moirai_parallel::scope` included — survives admission backpressure.
 - [x] [arch] ISSUE-219: Move `moirai-iter`'s recursive sort fork-join off the

--- a/moirai-executor/src/schedule/runtime/blocking.rs
+++ b/moirai-executor/src/schedule/runtime/blocking.rs
@@ -14,7 +14,10 @@ use moirai_core::{
     Priority,
 };
 
-use super::{super::job::ScheduledJob, types::SchedulerInner, worker::execute_blocking_job};
+use super::{
+    super::job::ScheduledJob, scheduler::RefusedJob, types::SchedulerInner,
+    worker::execute_blocking_job,
+};
 
 const PRIORITY_LEVELS: usize = 4;
 
@@ -171,21 +174,23 @@ impl<const QUEUE_CAPACITY: usize> BlockingLane<QUEUE_CAPACITY> {
         locality_hint: Option<usize>,
         job: ScheduledJob,
         pending_tasks: &AtomicUsize,
-    ) -> ExecutorResult<()> {
+    ) -> Result<(), RefusedJob> {
         let lane_id = locality_hint.unwrap_or_else(next_lane_ticket) % self.queues.len();
         let mut job = Some(job);
         match self.queues[lane_id].try_push(priority, &mut job, pending_tasks) {
             Ok(()) => Ok(()),
-            Err(BlockingAdmission::Full) => {
-                drop(job);
-                Err(ExecutorError::ResourceExhausted(format!(
+            // `try_push` leaves a refused job in the slot, so it is handed back
+            // rather than dropped: it never ran, and its owner may still run it.
+            Err(BlockingAdmission::Full) => Err(RefusedJob {
+                error: ExecutorError::ResourceExhausted(format!(
                     "blocking lane {lane_id} admission queue is full"
-                )))
-            }
-            Err(BlockingAdmission::ShuttingDown) => {
-                drop(job);
-                Err(ExecutorError::ShuttingDown)
-            }
+                )),
+                job,
+            }),
+            Err(BlockingAdmission::ShuttingDown) => Err(RefusedJob {
+                error: ExecutorError::ShuttingDown,
+                job,
+            }),
         }
     }
 

--- a/moirai-executor/src/schedule/runtime/blocking.rs
+++ b/moirai-executor/src/schedule/runtime/blocking.rs
@@ -14,10 +14,7 @@ use moirai_core::{
     Priority,
 };
 
-use super::{
-    super::job::ScheduledJob, scheduler::RefusedJob, types::SchedulerInner,
-    worker::execute_blocking_job,
-};
+use super::{super::job::ScheduledJob, types::SchedulerInner, worker::execute_blocking_job};
 
 const PRIORITY_LEVELS: usize = 4;
 
@@ -172,25 +169,18 @@ impl<const QUEUE_CAPACITY: usize> BlockingLane<QUEUE_CAPACITY> {
         &self,
         priority: Priority,
         locality_hint: Option<usize>,
-        job: ScheduledJob,
+        job: &mut Option<ScheduledJob>,
         pending_tasks: &AtomicUsize,
-    ) -> Result<(), RefusedJob> {
+    ) -> ExecutorResult<()> {
         let lane_id = locality_hint.unwrap_or_else(next_lane_ticket) % self.queues.len();
-        let mut job = Some(job);
-        match self.queues[lane_id].try_push(priority, &mut job, pending_tasks) {
+        // `try_push` leaves a refused job in the slot rather than consuming it:
+        // it never ran, and its owner may still run it.
+        match self.queues[lane_id].try_push(priority, job, pending_tasks) {
             Ok(()) => Ok(()),
-            // `try_push` leaves a refused job in the slot, so it is handed back
-            // rather than dropped: it never ran, and its owner may still run it.
-            Err(BlockingAdmission::Full) => Err(RefusedJob {
-                error: ExecutorError::ResourceExhausted(format!(
-                    "blocking lane {lane_id} admission queue is full"
-                )),
-                job,
-            }),
-            Err(BlockingAdmission::ShuttingDown) => Err(RefusedJob {
-                error: ExecutorError::ShuttingDown,
-                job,
-            }),
+            Err(BlockingAdmission::Full) => Err(ExecutorError::ResourceExhausted(format!(
+                "blocking lane {lane_id} admission queue is full"
+            ))),
+            Err(BlockingAdmission::ShuttingDown) => Err(ExecutorError::ShuttingDown),
         }
     }
 

--- a/moirai-executor/src/schedule/runtime/scheduler/core.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/core.rs
@@ -28,6 +28,34 @@ use super::super::worker::{
     wake_contended_workers, wake_worker, JOIN_FAST_SPIN_ATTEMPTS,
 };
 
+/// A job admission refused, with the job returned when it is still runnable.
+///
+/// Admission failure and job loss are separate facts. A job rejected by a full
+/// queue never ran and can still be run by whoever holds it, so it comes back
+/// with the error; a job the lane consumed while failing does not. Callers that
+/// can execute the work themselves — a scope, which owes its caller that every
+/// spawned job runs — check `job` rather than assuming either.
+pub(crate) struct RefusedJob {
+    pub(crate) error: ExecutorError,
+    pub(crate) job: Option<ScheduledJob>,
+}
+
+impl RefusedJob {
+    /// The job never entered a queue and can still be run.
+    pub(crate) fn runnable(error: ExecutorError, job: ScheduledJob) -> Self {
+        Self {
+            error,
+            job: Some(job),
+        }
+    }
+
+    /// A shutting-down scheduler refuses admission. The job is returned, but a
+    /// caller running it must be sure the work is still wanted at shutdown.
+    pub(crate) fn shutting_down(job: ScheduledJob) -> Self {
+        Self::runnable(ExecutorError::ShuttingDown, job)
+    }
+}
+
 /// Busy-spin iterations a worker-thread scope waiter performs after exhausting
 /// runnable work before it parks on the scope condvar. The waiter only reaches
 /// this path when its remaining scoped jobs are actively executing on other
@@ -257,6 +285,42 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
         }
     }
 
+    /// Schedule a scoped job, handing it back when admission refuses it.
+    ///
+    /// # Safety
+    ///
+    /// Same contract as [`ScheduledJob::new_scoped`]: the caller must prove
+    /// every job is executed or dropped before the borrowed scope ends. A
+    /// refused job is returned rather than dropped, so the caller owns that
+    /// obligation for it too.
+    pub(crate) unsafe fn admit_scoped_job<'scope, C, F>(
+        &self,
+        priority: Priority,
+        locality_hint: Option<usize>,
+        scoped_job: F,
+    ) -> Result<(), RefusedJob>
+    where
+        C: WorkClass,
+        F: FnOnce(usize) + Send + 'scope,
+    {
+        // Safety: discharged by this function's own contract.
+        let job = unsafe { ScheduledJob::new_scoped(scoped_job) };
+        self.admit_job::<C>(priority, locality_hint, job)
+    }
+
+    /// Lane identifier passed to a job the caller runs itself.
+    ///
+    /// Worker lanes are `0..worker_count()`; the calling thread is the lane
+    /// past the last worker. It is a lane identity, never an index into the
+    /// worker set.
+    pub(crate) fn caller_lane_id(&self) -> usize {
+        get_current_worker_id().unwrap_or_else(|| self.worker_count())
+    }
+
+    /// Schedule a job, dropping it if admission refuses it.
+    ///
+    /// Callers that can still run a refused job themselves use
+    /// [`Self::admit_job`] instead.
     pub(crate) fn schedule_job<C>(
         &self,
         priority: Priority,
@@ -266,14 +330,34 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
     where
         C: WorkClass,
     {
+        self.admit_job::<C>(priority, locality_hint, job)
+            .map_err(|refused| refused.error)
+    }
+
+    /// Schedule a job, handing it back when admission refuses it.
+    ///
+    /// A refused job has not run and never will unless the caller runs it, so
+    /// dropping it silently discards work. Returning it lets the caller choose:
+    /// `SchedulerScope::flush` runs it on the calling lane, which is how a scope
+    /// keeps its "every spawned job runs before the scope returns" contract
+    /// under admission backpressure.
+    pub(crate) fn admit_job<C>(
+        &self,
+        priority: Priority,
+        locality_hint: Option<usize>,
+        job: ScheduledJob,
+    ) -> Result<(), RefusedJob>
+    where
+        C: WorkClass,
+    {
         if self.inner.shutdown.load(Ordering::Acquire) {
-            return Err(ExecutorError::ShuttingDown);
+            return Err(RefusedJob::shutting_down(job));
         }
 
         if C::USES_BLOCKING_LANE {
             if let Some(lane) = self.inner.blocking_lane.get() {
                 if self.inner.shutdown.load(Ordering::Acquire) {
-                    return Err(ExecutorError::ShuttingDown);
+                    return Err(RefusedJob::shutting_down(job));
                 }
                 return lane.submit(
                     priority,
@@ -285,13 +369,20 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
 
             let _lane_init = lock_mutex(&self.inner.blocking_lane_init);
             if self.inner.shutdown.load(Ordering::Acquire) {
-                return Err(ExecutorError::ShuttingDown);
+                return Err(RefusedJob::shutting_down(job));
             }
             if self.inner.blocking_lane.get().is_none() {
                 let candidate = super::super::blocking::BlockingLane::new(self.worker_count());
-                candidate.start(Arc::clone(&self.inner), &self.inner.blocking_lane_prefix)?;
+                if let Err(error) =
+                    candidate.start(Arc::clone(&self.inner), &self.inner.blocking_lane_prefix)
+                {
+                    return Err(RefusedJob::runnable(error, job));
+                }
                 if self.inner.blocking_lane.set(candidate).is_err() {
-                    return Err(ExecutorError::ThreadPoolCreationFailed);
+                    return Err(RefusedJob::runnable(
+                        ExecutorError::ThreadPoolCreationFailed,
+                        job,
+                    ));
                 }
             }
             let lane = self
@@ -345,10 +436,12 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
 
         if let Some(job) = rejected {
             self.inner.pending_tasks.fetch_sub(1, Ordering::SeqCst);
-            drop(job);
-            return Err(ExecutorError::ResourceExhausted(format!(
-                "worker {worker_index} scheduler admission queue is full"
-            )));
+            return Err(RefusedJob::runnable(
+                ExecutorError::ResourceExhausted(format!(
+                    "worker {worker_index} scheduler admission queue is full"
+                )),
+                job,
+            ));
         }
 
         // Try to wake up an idle worker via the lock-free wake lottery. The

--- a/moirai-executor/src/schedule/runtime/scheduler/core.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/core.rs
@@ -28,34 +28,6 @@ use super::super::worker::{
     wake_contended_workers, wake_worker, JOIN_FAST_SPIN_ATTEMPTS,
 };
 
-/// A job admission refused, with the job returned when it is still runnable.
-///
-/// Admission failure and job loss are separate facts. A job rejected by a full
-/// queue never ran and can still be run by whoever holds it, so it comes back
-/// with the error; a job the lane consumed while failing does not. Callers that
-/// can execute the work themselves — a scope, which owes its caller that every
-/// spawned job runs — check `job` rather than assuming either.
-pub(crate) struct RefusedJob {
-    pub(crate) error: ExecutorError,
-    pub(crate) job: Option<ScheduledJob>,
-}
-
-impl RefusedJob {
-    /// The job never entered a queue and can still be run.
-    pub(crate) fn runnable(error: ExecutorError, job: ScheduledJob) -> Self {
-        Self {
-            error,
-            job: Some(job),
-        }
-    }
-
-    /// A shutting-down scheduler refuses admission. The job is returned, but a
-    /// caller running it must be sure the work is still wanted at shutdown.
-    pub(crate) fn shutting_down(job: ScheduledJob) -> Self {
-        Self::runnable(ExecutorError::ShuttingDown, job)
-    }
-}
-
 /// Busy-spin iterations a worker-thread scope waiter performs after exhausting
 /// runnable work before it parks on the scope condvar. The waiter only reaches
 /// this path when its remaining scoped jobs are actively executing on other
@@ -285,29 +257,6 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
         }
     }
 
-    /// Schedule a scoped job, handing it back when admission refuses it.
-    ///
-    /// # Safety
-    ///
-    /// Same contract as [`ScheduledJob::new_scoped`]: the caller must prove
-    /// every job is executed or dropped before the borrowed scope ends. A
-    /// refused job is returned rather than dropped, so the caller owns that
-    /// obligation for it too.
-    pub(crate) unsafe fn admit_scoped_job<'scope, C, F>(
-        &self,
-        priority: Priority,
-        locality_hint: Option<usize>,
-        scoped_job: F,
-    ) -> Result<(), RefusedJob>
-    where
-        C: WorkClass,
-        F: FnOnce(usize) + Send + 'scope,
-    {
-        // Safety: discharged by this function's own contract.
-        let job = unsafe { ScheduledJob::new_scoped(scoped_job) };
-        self.admit_job::<C>(priority, locality_hint, job)
-    }
-
     /// Lane identifier passed to a job the caller runs itself.
     ///
     /// Worker lanes are `0..worker_count()`; the calling thread is the lane
@@ -330,34 +279,40 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
     where
         C: WorkClass,
     {
-        self.admit_job::<C>(priority, locality_hint, job)
-            .map_err(|refused| refused.error)
+        self.admit_job::<C>(priority, locality_hint, &mut Some(job))
     }
 
-    /// Schedule a job, handing it back when admission refuses it.
+    /// Schedule a job, leaving it in `job` when admission refuses it.
     ///
     /// A refused job has not run and never will unless the caller runs it, so
-    /// dropping it silently discards work. Returning it lets the caller choose:
-    /// `SchedulerScope::flush` runs it on the calling lane, which is how a scope
-    /// keeps its "every spawned job runs before the scope returns" contract
-    /// under admission backpressure.
+    /// dropping it silently discards work. Admission failure and job loss are
+    /// separate facts: a job a full queue turned away is still in `job` and
+    /// still runnable, while one a lane consumed while failing is not, so the
+    /// caller checks rather than assumes. `SchedulerScope::flush` runs what is
+    /// left behind on the calling lane, which is how a scope keeps its "every
+    /// spawned job runs before the scope returns" contract under backpressure.
+    ///
+    /// The job travels by slot rather than inside the error so the hot path
+    /// keeps a small `Result`: a `ScheduledJob` carries inline, cache-line
+    /// aligned storage, and an `Err` variant holding one would widen every
+    /// admission return, success included.
     pub(crate) fn admit_job<C>(
         &self,
         priority: Priority,
         locality_hint: Option<usize>,
-        job: ScheduledJob,
-    ) -> Result<(), RefusedJob>
+        job: &mut Option<ScheduledJob>,
+    ) -> ExecutorResult<()>
     where
         C: WorkClass,
     {
         if self.inner.shutdown.load(Ordering::Acquire) {
-            return Err(RefusedJob::shutting_down(job));
+            return Err(ExecutorError::ShuttingDown);
         }
 
         if C::USES_BLOCKING_LANE {
             if let Some(lane) = self.inner.blocking_lane.get() {
                 if self.inner.shutdown.load(Ordering::Acquire) {
-                    return Err(RefusedJob::shutting_down(job));
+                    return Err(ExecutorError::ShuttingDown);
                 }
                 return lane.submit(
                     priority,
@@ -369,20 +324,13 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
 
             let _lane_init = lock_mutex(&self.inner.blocking_lane_init);
             if self.inner.shutdown.load(Ordering::Acquire) {
-                return Err(RefusedJob::shutting_down(job));
+                return Err(ExecutorError::ShuttingDown);
             }
             if self.inner.blocking_lane.get().is_none() {
                 let candidate = super::super::blocking::BlockingLane::new(self.worker_count());
-                if let Err(error) =
-                    candidate.start(Arc::clone(&self.inner), &self.inner.blocking_lane_prefix)
-                {
-                    return Err(RefusedJob::runnable(error, job));
-                }
+                candidate.start(Arc::clone(&self.inner), &self.inner.blocking_lane_prefix)?;
                 if self.inner.blocking_lane.set(candidate).is_err() {
-                    return Err(RefusedJob::runnable(
-                        ExecutorError::ThreadPoolCreationFailed,
-                        job,
-                    ));
+                    return Err(ExecutorError::ThreadPoolCreationFailed);
                 }
             }
             let lane = self
@@ -419,10 +367,13 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
         // (On x86 `lock xadd` is already full-barrier, so this is free.)
         let previous_pending = self.inner.pending_tasks.fetch_add(1, Ordering::SeqCst);
 
+        let admitting = job
+            .take()
+            .expect("invariant: job is present before admission");
         let rejected = if get_current_worker_id() == Some(worker_index) {
             self.inner.workers[worker_index]
                 .lifo_slot
-                .try_push(job)
+                .try_push(admitting)
                 .and_then(|job| {
                     self.inner.workers[worker_index]
                         .queues
@@ -431,17 +382,17 @@ impl<const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
         } else {
             self.inner.workers[worker_index]
                 .queues
-                .try_push_external(priority, job)
+                .try_push_external(priority, admitting)
         };
 
-        if let Some(job) = rejected {
+        if let Some(rejected) = rejected {
             self.inner.pending_tasks.fetch_sub(1, Ordering::SeqCst);
-            return Err(RefusedJob::runnable(
-                ExecutorError::ResourceExhausted(format!(
-                    "worker {worker_index} scheduler admission queue is full"
-                )),
-                job,
-            ));
+            // Back in the caller's slot: it never entered a queue, so whoever
+            // owns the slot can still run it.
+            *job = Some(rejected);
+            return Err(ExecutorError::ResourceExhausted(format!(
+                "worker {worker_index} scheduler admission queue is full"
+            )));
         }
 
         // Try to wake up an idle worker via the lock-free wake lottery. The

--- a/moirai-executor/src/schedule/runtime/scheduler/mod.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/mod.rs
@@ -4,5 +4,7 @@ pub mod core;
 pub mod data_parallel;
 pub mod scope;
 
+pub(crate) use core::RefusedJob;
+
 #[cfg(feature = "scheduler-diagnostics")]
 pub mod diagnostics;

--- a/moirai-executor/src/schedule/runtime/scheduler/mod.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/mod.rs
@@ -4,7 +4,5 @@ pub mod core;
 pub mod data_parallel;
 pub mod scope;
 
-pub(crate) use core::RefusedJob;
-
 #[cfg(feature = "scheduler-diagnostics")]
 pub mod diagnostics;

--- a/moirai-executor/src/schedule/runtime/scheduler/scope.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/scope.rs
@@ -6,10 +6,11 @@ use std::{
     panic::{catch_unwind, AssertUnwindSafe},
 };
 
-use moirai_core::error::ExecutorResult;
+use moirai_core::error::{ExecutorError, ExecutorResult};
 
 use super::super::super::{class::WorkClass, job::ScheduledJob};
 use super::super::types::{SchedulerScope, SchedulerScopeState, ScopedTaskCompletion};
+use super::core::RefusedJob;
 
 impl<'scope, C, const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
     SchedulerScope<'scope, C, QUEUE_CAPACITY, SPIN_LIMIT>
@@ -92,9 +93,10 @@ where
     }
 
     fn schedule_single(&self, job: ScheduledJob) -> ExecutorResult<()> {
-        self.scheduler
-            .schedule_job::<C>(self.priority, self.locality_hint, job)?;
-        Ok(())
+        let admitted = self
+            .scheduler
+            .admit_job::<C>(self.priority, self.locality_hint, job);
+        self.run_if_refused(admitted)
     }
 
     fn schedule_chunk(&self, jobs: Vec<ScheduledJob>) -> ExecutorResult<()> {
@@ -104,12 +106,45 @@ where
             }
         };
 
-        self.scheduler.schedule_scoped_job::<C, _>(
-            self.priority,
-            self.locality_hint,
-            scoped_job,
-        )?;
-        Ok(())
+        // Safety: `ThreadScheduler::scope` waits for every scheduled scoped job
+        // and drops unscheduled buffered jobs before borrowed scope data can
+        // expire. A refused job is executed below, inside the same scope, so it
+        // observes the same live borrows.
+        let admitted = unsafe {
+            self.scheduler
+                .admit_scoped_job::<C, _>(self.priority, self.locality_hint, scoped_job)
+        };
+        self.run_if_refused(admitted)
+    }
+
+    /// Run a job the scheduler refused on the calling lane.
+    ///
+    /// A scope promises its caller that every spawned job runs before the scope
+    /// returns. Dropping a job the admission queue rejected breaks that promise
+    /// silently: the caller blocks until the scope joins and then continues as
+    /// though the work happened. Running it here keeps the promise at the cost
+    /// of the parallelism that job would have had — the same trade
+    /// `for_each_indexed` already makes with a rejected chunk, counted by the
+    /// same `admission_caller_runs` surface.
+    ///
+    /// Shutdown is not backpressure and is not absorbed: a scheduler that is
+    /// going away refuses the work, and the error reaches the caller.
+    fn run_if_refused(&self, admitted: Result<(), RefusedJob>) -> ExecutorResult<()> {
+        let Err(refused) = admitted else {
+            return Ok(());
+        };
+
+        match (refused.error, refused.job) {
+            (ExecutorError::ResourceExhausted(_), Some(job)) => {
+                self.scheduler.record_admission_caller_run();
+                // `execute` contains its own unwind boundary, so a panicking
+                // job marks its completion token failed exactly as it would on
+                // a worker instead of unwinding through the scope body.
+                let _ = job.execute(self.scheduler.caller_lane_id());
+                Ok(())
+            }
+            (error, _) => Err(error),
+        }
     }
 
     fn state(&self) -> &SchedulerScopeState {

--- a/moirai-executor/src/schedule/runtime/scheduler/scope.rs
+++ b/moirai-executor/src/schedule/runtime/scheduler/scope.rs
@@ -10,7 +10,6 @@ use moirai_core::error::{ExecutorError, ExecutorResult};
 
 use super::super::super::{class::WorkClass, job::ScheduledJob};
 use super::super::types::{SchedulerScope, SchedulerScopeState, ScopedTaskCompletion};
-use super::core::RefusedJob;
 
 impl<'scope, C, const QUEUE_CAPACITY: usize, const SPIN_LIMIT: usize>
     SchedulerScope<'scope, C, QUEUE_CAPACITY, SPIN_LIMIT>
@@ -23,6 +22,11 @@ where
     /// coalesced into worker-sized scheduler batches and complete before
     /// `ThreadScheduler::scope` returns. Jobs are not guaranteed to start while
     /// the scope body is still registering work.
+    ///
+    /// The `usize` the job receives identifies the lane running it. Worker
+    /// lanes are `0..worker_count()`; a job the admission queue turned away
+    /// runs on the calling lane, identified as `worker_count()`. It is a lane
+    /// identity, not an index into the worker set.
     pub fn spawn<F>(&self, task: F) -> ExecutorResult<()>
     where
         F: FnOnce(usize) + Send + 'scope,
@@ -93,10 +97,11 @@ where
     }
 
     fn schedule_single(&self, job: ScheduledJob) -> ExecutorResult<()> {
+        let mut job = Some(job);
         let admitted = self
             .scheduler
-            .admit_job::<C>(self.priority, self.locality_hint, job);
-        self.run_if_refused(admitted)
+            .admit_job::<C>(self.priority, self.locality_hint, &mut job);
+        self.run_if_refused(admitted, job)
     }
 
     fn schedule_chunk(&self, jobs: Vec<ScheduledJob>) -> ExecutorResult<()> {
@@ -108,13 +113,10 @@ where
 
         // Safety: `ThreadScheduler::scope` waits for every scheduled scoped job
         // and drops unscheduled buffered jobs before borrowed scope data can
-        // expire. A refused job is executed below, inside the same scope, so it
+        // expire. A refused job runs below, inside the same scope, so it
         // observes the same live borrows.
-        let admitted = unsafe {
-            self.scheduler
-                .admit_scoped_job::<C, _>(self.priority, self.locality_hint, scoped_job)
-        };
-        self.run_if_refused(admitted)
+        let job = unsafe { ScheduledJob::new_scoped(scoped_job) };
+        self.schedule_single(job)
     }
 
     /// Run a job the scheduler refused on the calling lane.
@@ -129,13 +131,14 @@ where
     ///
     /// Shutdown is not backpressure and is not absorbed: a scheduler that is
     /// going away refuses the work, and the error reaches the caller.
-    fn run_if_refused(&self, admitted: Result<(), RefusedJob>) -> ExecutorResult<()> {
-        let Err(refused) = admitted else {
-            return Ok(());
-        };
-
-        match (refused.error, refused.job) {
-            (ExecutorError::ResourceExhausted(_), Some(job)) => {
+    fn run_if_refused(
+        &self,
+        admitted: ExecutorResult<()>,
+        refused: Option<ScheduledJob>,
+    ) -> ExecutorResult<()> {
+        match (admitted, refused) {
+            (Ok(()), _) => Ok(()),
+            (Err(ExecutorError::ResourceExhausted(_)), Some(job)) => {
                 self.scheduler.record_admission_caller_run();
                 // `execute` contains its own unwind boundary, so a panicking
                 // job marks its completion token failed exactly as it would on
@@ -143,7 +146,7 @@ where
                 let _ = job.execute(self.scheduler.caller_lane_id());
                 Ok(())
             }
-            (error, _) => Err(error),
+            (Err(error), _) => Err(error),
         }
     }
 

--- a/moirai-executor/src/schedule/runtime/tests.rs
+++ b/moirai-executor/src/schedule/runtime/tests.rs
@@ -181,6 +181,108 @@ fn saturated_indexed_admission_runs_rejected_chunks_on_caller() {
 }
 
 #[test]
+fn saturated_scope_admission_runs_rejected_jobs_on_caller() {
+    // A scope owes its caller that every spawned job ran by the time it
+    // returns. `flush` used to drop a job the admission queue rejected, so the
+    // caller resumed as though borrowed work had happened when it never did —
+    // silent, and invisible to the scope's own counters, which the dropped
+    // job's completion token decrements either way.
+    const ADMISSION_CAPACITY: usize = crate::schedule::queue::INJECTOR_CAPACITY;
+    const SCOPED_JOBS: usize = 4;
+
+    let scheduler = ThreadScheduler::<256>::new(1, "scope-caller-runs").unwrap();
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    scheduler
+        .schedule::<SyncTask, _>(Priority::Normal, None, move |_| {
+            started_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        })
+        .unwrap();
+    started_rx.recv().unwrap();
+
+    for _ in 0..ADMISSION_CAPACITY {
+        scheduler
+            .schedule::<SyncTask, _>(Priority::Normal, None, |_| {})
+            .unwrap();
+    }
+
+    let caller_runs_before = scheduler.admission_caller_runs();
+    let visits: [AtomicUsize; SCOPED_JOBS] = std::array::from_fn(|_| AtomicUsize::new(0));
+    let lanes: [AtomicUsize; SCOPED_JOBS] = std::array::from_fn(|_| AtomicUsize::new(usize::MAX));
+
+    scheduler
+        .scope::<SyncTask, _>(Priority::Normal, None, |scope| {
+            for (index, (visit, lane)) in visits.iter().zip(lanes.iter()).enumerate() {
+                scope.spawn(move |worker_id| {
+                    visit.fetch_add(1, Ordering::Relaxed);
+                    lane.store(worker_id, Ordering::Relaxed);
+                    let _ = index;
+                })?;
+            }
+            Ok(())
+        })
+        .expect("a saturated scope must still complete every spawned job");
+
+    // Exactly once each: the refused job runs on the caller instead of being
+    // dropped, and it must not also reach a worker.
+    for visit in &visits {
+        assert_eq!(visit.load(Ordering::Relaxed), 1);
+    }
+    // The caller's lane is the one past the last worker, never a worker index.
+    for lane in &lanes {
+        assert_eq!(lane.load(Ordering::Relaxed), scheduler.worker_count());
+    }
+    assert!(
+        scheduler.admission_caller_runs() > caller_runs_before,
+        "the caller-run backpressure event must be surfaced, not silent"
+    );
+
+    release_tx.send(()).unwrap();
+    scheduler.join().unwrap();
+    assert_eq!(scheduler.pending_tasks(), 0);
+    scheduler.shutdown();
+}
+
+#[test]
+fn saturated_scope_propagates_a_caller_run_job_panic() {
+    // A job the caller runs keeps a worker's panic semantics: the scope reports
+    // failure rather than unwinding through the scope body.
+    const ADMISSION_CAPACITY: usize = crate::schedule::queue::INJECTOR_CAPACITY;
+
+    let scheduler = ThreadScheduler::<256>::new(1, "scope-caller-panic").unwrap();
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    scheduler
+        .schedule::<SyncTask, _>(Priority::Normal, None, move |_| {
+            started_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        })
+        .unwrap();
+    started_rx.recv().unwrap();
+
+    for _ in 0..ADMISSION_CAPACITY {
+        scheduler
+            .schedule::<SyncTask, _>(Priority::Normal, None, |_| {})
+            .unwrap();
+    }
+
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let scoped = scheduler.scope::<SyncTask, _>(Priority::Normal, None, |scope| {
+        scope.spawn(|_| panic!("caller-run scoped job panic"))?;
+        Ok(())
+    });
+    std::panic::set_hook(previous_hook);
+
+    assert_eq!(scoped, Err(ExecutorError::SpawnFailed(TaskError::Panicked)));
+
+    release_tx.send(()).unwrap();
+    scheduler.join().unwrap();
+    scheduler.shutdown();
+}
+
+#[test]
 fn blocking_lane_preserves_compute_progress_when_full() {
     let scheduler = ThreadScheduler::new(2, "blocking-lane-progress").unwrap();
     let blocking_started = Arc::new(Barrier::new(3));

--- a/moirai-parallel/src/ops.rs
+++ b/moirai-parallel/src/ops.rs
@@ -216,11 +216,14 @@ impl<'scope> Scope<'scope> {
     ///
     /// The task may borrow values that outlive the scope call. The scope waits
     /// for every spawned task before returning, so borrowed data cannot escape.
+    /// A task the scheduler's admission queue turns away runs on the calling
+    /// thread instead, so backpressure costs parallelism rather than the task.
     ///
     /// # Panics
     ///
-    /// Panics if the underlying scheduler rejects the spawn (for example, if the
-    /// executor is shutting down).
+    /// Panics if the underlying scheduler refuses to register the task, which
+    /// registration itself does not do — the failure surfaces from [`scope`]
+    /// when the scheduler is shutting down.
     #[inline]
     pub fn spawn<F>(&self, task: F)
     where


### PR DESCRIPTION
ISSUE-221, filed by the `join_with` fix (#103) as the part a caller-side slot
could not reach.

`ThreadScheduler::schedule_job` dropped a job the admission queue rejected and
returned only the error, so `SchedulerScope::flush` had nothing to recover. A
scope owes its caller that every spawned job ran by the time it returns, and
dropping one broke that **silently**: the dropped job's completion token
decrements the scope's pending count exactly as a finished job's does, so the
scope joined cleanly and the caller resumed as though borrowed work had
happened. `moirai_parallel::scope` turned the error into a panic instead.

`for_each_indexed` already had the right answer for the same condition — run
the rejected chunk inline — but only because it owns its index domain and can
reconstruct the work. A scope holds opaque closures, so the job itself has to
come back.

## Change

Admission takes the job in an `&mut Option` slot the caller owns and leaves it
there when it refuses — the shape `BlockingQueue::try_push` already used.
Refused means the slot is still full; a job a lane consumed while failing
leaves it empty, so the caller checks rather than assumes.

`flush` runs what is left behind on its own lane, through the job's existing
unwind boundary (`ScheduledJob::execute` already catches), and counts it with
`record_admission_caller_run` — the same surface the indexed path uses, so the
backpressure event stays visible rather than becoming silent sequential
execution. `schedule_chunk` collapses onto `schedule_single`.

**Shutdown is not backpressure and is not absorbed** — a scheduler that is
going away refuses the work and the error reaches the caller.

I first returned the job inside the error. `clippy::result_large_err` caught
what that costs: `ScheduledJob` carries inline cache-line-aligned storage, so
the `Err` variant widened every admission result to 192 bytes, success path
included. The slot keeps the hot path's `Result` small; that reshape is its own
commit.

## Evidence

Red→green, verified by reverting the four source files to the parent revision
and re-running the new tests:

- `saturated_scope_admission_runs_rejected_jobs_on_caller` — fails before
  (spawned jobs never run), passes after. Asserts each job ran exactly once,
  that the lane id they observe is the caller lane, and that
  `admission_caller_runs` moved.
- `saturated_scope_propagates_a_caller_run_job_panic` — fails before with
  `Err(ResourceExhausted)`, which *is* the proof the job was dropped rather
  than run; passes after with `Err(SpawnFailed(Panicked))`, matching worker
  semantics.

Both saturate a one-worker scheduler's injector deterministically, the same
construction the existing indexed-admission test uses.

`moirai-executor` 91/91; 343/343 across executor/parallel/iter/moirai; fmt,
`clippy --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`,
doctests, and workspace `cargo check --all-targets` clean.

## Limits worth knowing

- Verified at the scheduler layer, where admission saturates deterministically.
  `moirai_parallel::scope` inherits the fix through the same `flush` but has no
  test of its own — saturating the process-wide executor from that layer would
  be a fragile test, not a better one.
- A refused job now runs on the caller's thread. For a non-worker caller that
  is a thread the closure was not written for; the `usize` it receives is
  documented on `SchedulerScope::spawn` as a lane identity (`worker_count()`
  for the caller), never an index into the worker set. A closure that assumed a
  worker lane is a caller-side contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical correctness issue where scoped jobs rejected by the admission queue were silently dropped instead of executed, breaking the scope's guarantee that all spawned jobs run before returning. The fix changes the admission API to leave rejected jobs in a caller-owned slot (rather than dropping them), allowing `SchedulerScope::flush` to run refused jobs inline on the calling thread with proper panic boundaries and backpressure tracking. The change maintains the hot path performance by avoiding large `Result` types and adds comprehensive tests that verify rejected jobs run exactly once on the caller's lane.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-executor/src/schedule/runtime/scheduler/core.rs` |
| 2 | `moirai-executor/src/schedule/runtime/scheduler/scope.rs` |
| 3 | `moirai-executor/src/schedule/runtime/blocking.rs` |
| 4 | `moirai-executor/src/schedule/runtime/tests.rs` |
| 5 | `moirai-parallel/src/ops.rs` |
| 6 | `CHANGELOG.md` |
| 7 | `docs/backlog.md` |
| 8 | `docs/checklist.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->