### PR TITLE
Document FutexMutex and guard its guard's Sync bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "moirai-core",
  "moirai-utils",
  "proptest",
+ "static_assertions",
 ]
 
 [[package]]

--- a/moirai-sync/Cargo.toml
+++ b/moirai-sync/Cargo.toml
@@ -22,6 +22,9 @@ libc = "0.2"
 [dev-dependencies]
 criterion = { workspace = true }
 proptest = { workspace = true }
+# Asserts the auto-trait bounds of `FutexMutexGuard`, including the negative one
+# that a positive assertion cannot express.
+static_assertions = "1.1"
 
 [[bench]]
 name = "resource_pool"

--- a/moirai-sync/src/sync/futex_mutex.rs
+++ b/moirai-sync/src/sync/futex_mutex.rs
@@ -1,3 +1,43 @@
+//! Mutex backed by a Linux futex, with a condvar fallback elsewhere.
+//!
+//! Both builds present the same API and the same guarantees; only the blocking
+//! mechanism differs, so the two protocols are described separately below.
+//!
+//! # Linux: three-state futex
+//!
+//! `state` is the classic Drepper encoding — 0 unlocked, 1 locked, 2 locked with
+//! waiters. The one rule that is easy to get wrong is stated at `lock_slow`:
+//! every acquisition through the slow path takes the lock with `swap(2)` rather
+//! than `CAS 0 -> 1`, because unlock only wakes when it observes 2. Acquiring at
+//! 1 after a wakeup would erase that marker while other threads are still
+//! parked, and the next unlock would skip the wake and strand them.
+//!
+//! # Elsewhere: `locked` flag plus condvar
+//!
+//! A waiter registers in `waiters`, then blocks on `condvar` while holding
+//! `fallback`; the unlocker clears `locked` and notifies only if `waiters` is
+//! non-zero. That pair of accesses is a store-buffer pattern — the waiter stores
+//! `waiters` then loads `locked`, the unlocker stores `locked` then loads
+//! `waiters` — so both sides carry a `SeqCst` fence between their store and
+//! their load. Without them each load may miss the other's store, and the
+//! unlocker skips a notify for a waiter that is about to sleep forever. Holding
+//! `fallback` across the `locked` check and the `condvar.wait` is what keeps a
+//! notify from landing in between.
+//!
+//! # `Send` and `Sync`
+//!
+//! `FutexMutex<T>` is `Send + Sync` for `T: Send`, matching `std::sync::Mutex`:
+//! the lock hands `&mut T` to one thread at a time, so `T` must be able to move
+//! between threads, but never needs to be shared by two at once.
+//!
+//! `FutexMutexGuard` is deliberately `Send`, unlike `std::sync::MutexGuard`.
+//! Neither protocol requires the releasing thread to be the acquiring one: the
+//! futex state is a plain atomic, and `fallback` is only ever held inside
+//! `lock_slow`/`unlock`, never across the guard's lifetime.
+//!
+//! The guard's `PhantomData<T>` is load-bearing rather than decorative — see the
+//! note on the field.
+
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::hint;
@@ -21,6 +61,11 @@ mod futex {
 
     /// Wait on a futex if the value matches expected
     pub fn futex_wait(addr: *const i32, expected: i32) -> i32 {
+        // SAFETY: `addr` points at the caller's live `AtomicI32`. The kernel
+        // reads that word, compares it with `expected`, and blocks only while
+        // they match — the comparison is atomic with the sleep, so an unlock
+        // landing in between cannot be missed. The null timeout means no
+        // deadline, and the trailing arguments are unused by FUTEX_WAIT.
         unsafe {
             libc::syscall(
                 libc::SYS_futex,
@@ -36,6 +81,9 @@ mod futex {
 
     /// Wake up waiters on a futex
     pub fn futex_wake(addr: *const i32, num_waiters: i32) -> i32 {
+        // SAFETY: `addr` points at the caller's live `AtomicI32`. FUTEX_WAKE
+        // only reads the address as a queue key; it neither loads nor stores
+        // the word, and the trailing arguments are unused by this operation.
         unsafe {
             libc::syscall(
                 libc::SYS_futex,
@@ -82,6 +130,11 @@ impl<T> fmt::Debug for FutexMutex<T> {
     }
 }
 
+// SAFETY: the only non-`Sync` field is the `UnsafeCell<T>`, and it is reachable
+// solely through a guard, which the lock protocol hands to one thread at a time.
+// `T: Send` is therefore the exact bound — ownership of the data moves between
+// threads, but is never shared by two at once — and it is the same bound
+// `std::sync::Mutex` carries for the same reason.
 unsafe impl<T: Send> Send for FutexMutex<T> {}
 unsafe impl<T: Send> Sync for FutexMutex<T> {}
 
@@ -246,6 +299,14 @@ impl<T> FutexMutex<T> {
 /// Guard for FutexMutex that automatically unlocks on drop.
 pub struct FutexMutexGuard<'a, T> {
     mutex: &'a FutexMutex<T>,
+    /// Ties the guard's auto traits to `T`, which is what makes `Sync` require
+    /// `T: Sync`.
+    ///
+    /// Without this field the guard's only member would be
+    /// `&FutexMutex<T>`, and that is `Sync` for any `T: Send` — so the guard
+    /// would be `Sync` too, and `&guard` would hand out `&T` to several threads
+    /// for a `T` that cannot be shared. Removing this is a soundness change, not
+    /// a cleanup; `guard_sync_requires_sync_data` fails if it goes.
     _phantom: std::marker::PhantomData<T>,
 }
 
@@ -259,12 +320,40 @@ impl<'a, T> Deref for FutexMutexGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
+        // SAFETY: holding the guard means this thread holds the lock, so no
+        // other thread can hold a reference to the data at the same time.
         unsafe { &*self.mutex.data.get() }
     }
 }
 
 impl<'a, T> DerefMut for FutexMutexGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: as `deref`, and `&mut self` rules out any other borrow taken
+        // through this guard, so the returned reference is unique.
         unsafe { &mut *self.mutex.data.get() }
+    }
+}
+
+#[cfg(test)]
+mod auto_traits {
+    use super::{FutexMutex, FutexMutexGuard};
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+    use std::cell::Cell;
+
+    assert_impl_all!(FutexMutex<u32>: Send, Sync);
+
+    // Unlike `std::sync::MutexGuard`, this guard may cross threads: neither
+    // protocol requires the releasing thread to be the acquiring one.
+    assert_impl_all!(FutexMutexGuard<'static, u32>: Send, Sync);
+
+    /// `Sync` must follow `T`, not the mutex reference.
+    ///
+    /// `Cell<u32>` is `Send` but not `Sync`, so `&FutexMutex<Cell<u32>>` is
+    /// `Sync` on its own. Only the guard's `PhantomData<T>` stops the guard from
+    /// inheriting that and handing `&Cell<u32>` to several threads at once, so
+    /// this is the assertion that fails if the field is ever dropped.
+    #[allow(dead_code)]
+    fn guard_sync_requires_sync_data() {
+        assert_not_impl_any!(FutexMutexGuard<'static, Cell<u32>>: Sync);
     }
 }


### PR DESCRIPTION
Fifteenth increment of the moirai audit — `moirai-sync/src/sync/futex_mutex.rs`. Six unsafe sites, no safety comment, and two protocols that share an API but nothing else. Both are public API (`FutexMutex` and `FutexMutexGuard` are exported from the crate root).

## Audit result: sound

**Linux — three-state Drepper futex.** The rule that is easiest to get wrong was already reasoned in place: the slow path acquires with `swap(2)` rather than `CAS 0 -> 1`, because unlock wakes only when it observes 2. Acquiring at 1 after a wakeup would erase that marker while other threads are still parked, and the next unlock would skip the wake.

**Elsewhere — `locked` flag plus condvar.** The `SeqCst` fences on both sides close a real store-buffer race: the waiter stores `waiters` then loads `locked`, the unlocker stores `locked` then loads `waiters`, and without the fences each load may miss the other's store — the unlocker skips the notify while the waiter sleeps forever. Holding `fallback` across the `locked` check and the `condvar.wait` is separately what keeps a notify from landing between them.

## The subtle part: the guard's `PhantomData<T>` is load-bearing

```rust
pub struct FutexMutexGuard<'a, T> {
    mutex: &'a FutexMutex<T>,
    _phantom: std::marker::PhantomData<T>,
}
```

That field is what makes `Sync` require `T: Sync`. Without it the guard's only member is `&FutexMutex<T>`, which is `Sync` for any `T: Send` — so the guard would inherit `Sync` and hand out `&T` to several threads for a `T` that cannot be shared. It reads like an unused marker; deleting it is a soundness change.

**Verified by probe, not by argument.** Asking for `FutexMutexGuard<'static, Cell<u32>>: Sync` is rejected with *"within `FutexMutexGuard<...>`, the trait `Sync` is not implemented for `Cell<u32>`"*. Since `&FutexMutex<Cell<u32>>` is itself `Sync` (that needs only `Cell<u32>: Send`), the `PhantomData` is provably the sole field imposing the bound.

**Why this needs a dependency rather than a comment.** A positive assertion cannot express it: removing the field only *widens* the impl, so every `assert_impl_all` keeps passing. The guard has to be `assert_not_impl_any`, so `static_assertions` joins the dev-dependencies — already a direct dependency of `moirai-scheduler` and already in the lockfile. This is a soundness property on exported API; a comment does not fail a build.

Also recorded: the guard is deliberately `Send`, unlike `std::sync::MutexGuard`. That is correct here — neither protocol requires the releasing thread to be the acquiring one, since the futex state is a plain atomic and `fallback` is never held across the guard's lifetime.

## Verification

- `cargo fmt -p moirai-sync -- --check` ✓
- `cargo clippy -p moirai-sync --all-targets -- -D warnings` ✓
- `cargo nextest run -p moirai-sync` — 20/20 ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moirai-sync` ✓
- `cargo check -p moirai-sync --target x86_64-unknown-linux-gnu --tests` ✓ — this host compiles only the fallback, so the Linux futex path is cross-checked rather than left unverified.

Audit progress: seventeen moirai files — eleven sound, six with defects found and fixed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive documentation and safety comments to the `FutexMutex` implementation as part of an ongoing soundness audit. It documents the two protocol variants (Linux futex with Drepper three-state encoding, and a condvar-based fallback for other platforms), adds safety justifications for all unsafe operations, and introduces compile-time assertions to guard a critical soundness property: the `PhantomData<T>` field in `FutexMutexGuard` is essential for ensuring the guard's `Sync` bound properly requires `T: Sync`. Without this field, the guard could incorrectly allow sharing non-`Sync` types across threads. The PR adds `static_assertions` as a dev dependency to enforce this invariant at compile time, preventing accidental removal of the field.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-sync/Cargo.toml` |
| 2 | `moirai-sync/src/sync/futex_mutex.rs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->