### PR TITLE
Reach the SPSC channel only through its halves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **[breaking]** `SpscChannel` is no longer exported from `moirai-core`. The
+  single-producer/single-consumer discipline is enforced by `SpscSender` and
+  `SpscReceiver`, which are neither `Clone` nor `Sync`, but the bare channel
+  escaped alongside them: it implements `Channel<T>`, whose `send`/`recv` take
+  `&self`, and carried an `unsafe impl Sync`, so safe code could share one
+  channel and drive two producers into the same buffer slot — a data race, with
+  one value overwritten undropped, and a double free on the `recv` side.
+  Construct channels with `moirai_core::channel::spsc(capacity)`, which is
+  unchanged and returns the same pair; `SpscChannel::channel(n)` becomes
+  `channel::spsc(n)`. See ADR-024.
+
 - Run the `moirai-iter` parallel sorts' recursive fork-join on the unified
   scheduler's scope instead of the crate's own thread pool. That pool is a FIFO
   queue with no work stealing, so a worker blocked on another of its jobs could

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,7 @@ dependencies = [
  "mnemosyne",
  "moirai-utils",
  "proptest",
+ "static_assertions",
 ]
 
 [[package]]

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1385,3 +1385,108 @@ rustdoc and a workspace `--all-targets` check. `execute_iter` gains order and
 completeness tests plus a truncation regression, verified red against the
 parent revision. Evidence tier: empirical (value-semantic tests, red→green on
 the truncation defect) plus type-level (the deleted API cannot be reached).
+
+## ADR-024 (2026-07-27): SpscChannel is reached only through its halves
+
+- Status: Accepted [arch] [major] · Refs: PR #106 audit round
+
+**Intent.** Decide how `moirai-core`'s single-producer/single-consumer channel
+is exposed, given that its `Sync` impl is sound for the sender/receiver pair but
+not for the bare channel the crate also exported.
+
+**Context.** `moirai-core/src/channel/spsc.rs` is a bounded SPSC ring buffer.
+The protocol is correct and is not at issue: the producer loads `head` relaxed
+and `tail` acquire, writes the slot, then release-stores `head`; monotonic
+counters make the full check exact without a wasted slot; `Drop` drops exactly
+`[tail, head)`.
+
+The halves are correct too, and deliberately so. `SpscSender` and
+`SpscReceiver` are neither `Clone` — so at most one of each exists — nor `Sync`,
+because each carries a `PhantomData<Cell<()>>` that removes `Sync` while leaving
+`Send`. A half can therefore be moved to the thread that owns its role but never
+shared, which is what makes one producer and one consumer a type-level fact
+rather than a documented convention.
+
+The bare channel escaped alongside them. `SpscChannel` was exported twice, from
+`channel/mod.rs` and again from the crate root, with a `pub fn new`; it
+implements the exported `Channel<T>` trait, whose `send`/`recv` take `&self`;
+and it carries `unsafe impl<T: Send> Sync`. Those three facts compose into safe
+code that bypasses the discipline the halves enforce:
+
+```rust
+let ch = Arc::new(SpscChannel::<u64>::new(8));
+let (a, b) = (Arc::clone(&ch), Arc::clone(&ch));
+std::thread::spawn(move || { let _ = a.send(1); });
+std::thread::spawn(move || { let _ = b.send(2); });
+```
+
+Both producers load the same `head` and write `buffer[head & mask]`: a data race
+on one slot, with one `T` overwritten without being dropped. Two concurrent
+`recv` calls are worse — both `assume_init_read` the same slot, moving out of it
+twice and then dropping it twice. This was verified by compiling the program
+above as an integration test, which sees the crate as an external consumer; the
+runtime race was not demonstrated, and does not need to be, since a safe API
+that *can* produce it is already a defect.
+
+`SpscChannel` is the only channel in that module carrying an `unsafe impl Sync`.
+Mpmc and Hybrid need none. It exists to satisfy `Channel<T>: Send + Sync`, a
+supertrait written for genuinely shareable channels, and the SPSC type was
+fitted to a bound its access pattern cannot honour.
+
+**Constraints.**
+
+- The ring protocol and the halves' design are correct and stay unchanged.
+- `Sync` on the channel cannot simply be removed: both halves hold
+  `Arc<SpscChannel<T>>`, and `Arc<T>: Send` requires `T: Send + Sync`, so
+  dropping it would make the halves unsendable and break the intended use.
+- The fix must make misuse unrepresentable, not merely documented. A safe API
+  that can reach undefined behaviour is a defect regardless of what its docs say.
+
+**Options.**
+
+1. *Seal the channel.* Make `SpscChannel` `pub(crate)` and stop re-exporting it,
+   leaving `channel::spsc(capacity)` — already public, already the idiom used by
+   the crate's own tests — as the only way in. Subtractive; no behaviour change;
+   breaking only for code naming the type directly.
+2. *Drop the `Channel<T>` impl from `SpscChannel`.* Removes the `&self`
+   entry points but leaves a public type whose `Sync` impl is still unsound for
+   any inherent `&self` method added later. Treats a symptom.
+3. *Runtime producer claim.* An atomic flag turning concurrent misuse into a
+   panic. Non-breaking, but it adds a check to a low-latency hot path and
+   converts undefined behaviour into a panic rather than making it impossible.
+4. *Make it MPMC with compare-exchange on both indices.* Sound, and discards the
+   reason the type exists.
+
+**Decision.** Option 1. The halves already encode the invariant; the fix is to
+stop offering a way around them. `channel::spsc` is unchanged, so the supported
+path is untouched, and the only in-workspace user of the type — `select.rs`,
+through that same factory — needs no edit.
+
+**Consequences.**
+
+- *Breaking for direct users.* Code naming `moirai_core::channel::SpscChannel`
+  or `moirai_core::SpscChannel` no longer compiles. Migration is one line:
+  `SpscChannel::channel(n)` becomes `channel::spsc(n)`, returning the same pair.
+- *The `Channel` trait no longer has an SPSC implementor in its public surface.*
+  Generic code written against `Channel<T>` can still use `MpmcChannel` and
+  `HybridChannel`, which are genuinely shareable; an SPSC channel was never
+  substitutable there, and the trait bound had been asserting otherwise.
+- *The halves' `PhantomData<Cell<()>>` becomes load-bearing in a second way.* It
+  was always what kept them unshareable; now it is also the only barrier, since
+  the bare channel is gone. It reads like an unused field, so it is documented at
+  each site and pinned by an assertion.
+
+**Verification plan.**
+
+1. The exploit above must stop compiling — the same integration test that
+   demonstrated the hole, re-run against the sealed crate.
+2. `assert_not_impl_any!` on both halves' `Sync`, because a positive assertion
+   cannot express it: deleting the marker only widens the impls, so every
+   `assert_impl_all` keeps passing while the race returns.
+3. Existing SPSC channel tests stay green unchanged, proving the supported path
+   is unaffected.
+4. `cargo check --workspace --all-targets`, since removing a public export is
+   breaking and any in-workspace user must surface.
+5. `fmt --check`, `clippy --all-targets -D warnings`, `nextest`, and a
+   warning-denied `cargo doc`, with at least one gate run `--locked` because CI
+   passes it and a manifest change otherwise fails every job.

--- a/moirai-core/Cargo.toml
+++ b/moirai-core/Cargo.toml
@@ -25,6 +25,8 @@ bytemuck = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]
+# Asserts that the SPSC halves stay !Sync, which a positive assertion cannot express.
+static_assertions = "1.1"
 criterion = { workspace = true }
 proptest = { workspace = true }
 

--- a/moirai-core/src/channel/mod.rs
+++ b/moirai-core/src/channel/mod.rs
@@ -29,7 +29,7 @@ pub use error::{Channel, ChannelError, Result};
 pub use hybrid::{HybridChannel, HybridReceiver, HybridSender};
 pub use mpmc::{MpmcChannel, MpmcReceiver, MpmcSender};
 pub use select::{mpmc, spsc, unbounded, Select};
-pub use spsc::{SpscChannel, SpscReceiver, SpscSender};
+pub use spsc::{SpscReceiver, SpscSender};
 pub use stats::ChannelStatistics;
 pub use unified::{
     unified_channel, unified_channel_with_config, UnifiedChannel, UnifiedReceiver, UnifiedSender,

--- a/moirai-core/src/channel/spsc.rs
+++ b/moirai-core/src/channel/spsc.rs
@@ -16,9 +16,14 @@ use std::sync::Arc;
 /// budget matched to its condvar fallback.
 const SPSC_BLOCK_SPINS: usize = 6;
 
-/// Lock-free Single Producer Single Consumer channel
-/// Optimized for low latency with zero-copy semantics
-pub struct SpscChannel<T> {
+/// Lock-free single-producer/single-consumer channel.
+///
+/// Deliberately crate-private. `Channel::send`/`recv` take `&self`, and the
+/// `Sync` impl below lets `&SpscChannel` cross threads, so exposing the bare
+/// channel would let safe code drive two producers into the same slot. The
+/// discipline is enforced instead by [`SpscSender`]/[`SpscReceiver`], which are
+/// neither `Clone` nor `Sync`; reach them through `channel::spsc`.
+pub(crate) struct SpscChannel<T> {
     /// Ring buffer for messages (owns the `T` storage)
     buffer: Box<[UnsafeCell<MaybeUninit<T>>]>,
     /// Capacity mask for fast modulo
@@ -31,6 +36,16 @@ pub struct SpscChannel<T> {
     closed: AtomicBool,
 }
 
+// SAFETY: the buffer is only ever touched by one producer and one consumer,
+// each owning its own index — the producer writes a slot then releases `head`,
+// the consumer acquires `head` before reading it — so no slot is accessed by
+// two threads at once and `T: Send` is the exact bound for handing values
+// across the pair.
+//
+// `Sync` here is what lets one `Arc<SpscChannel>` back both halves, and it is
+// sound only because the halves impose the one-of-each discipline. That is why
+// the type is crate-private: on the bare channel, `&self` methods plus `Sync`
+// would let any number of threads produce at once.
 unsafe impl<T: Send> Send for SpscChannel<T> {}
 unsafe impl<T: Send> Sync for SpscChannel<T> {}
 
@@ -211,9 +226,19 @@ impl<T: Send> Channel<T> for SpscChannel<T> {
     }
 }
 
-/// Sender half of SPSC channel
+/// Sender half of SPSC channel.
+///
+/// The single-producer half of the pair: not `Clone`, so only one exists, and
+/// not `Sync`, so it cannot be shared while it exists.
 pub struct SpscSender<T> {
     pub(super) channel: Arc<SpscChannel<T>>,
+    /// Makes the sender `!Sync` while leaving it `Send`.
+    ///
+    /// `send` takes `&self`, so a `Sync` sender could be shared and driven by
+    /// two threads at once — both would claim the same slot. `Cell<()>` is
+    /// `Send` but not `Sync`, which permits moving the sender to another thread
+    /// and forbids sharing it. Removing this marker reopens the race;
+    /// `halves_are_not_sync` fails if it goes.
     _marker: PhantomData<std::cell::Cell<()>>,
 }
 
@@ -229,9 +254,14 @@ impl<T: Send> SpscSender<T> {
     }
 }
 
-/// Receiver half of SPSC channel
+/// Receiver half of SPSC channel.
+///
+/// The single-consumer half of the pair, `!Sync` for the same reason as
+/// [`SpscSender`] — two shared receivers would `assume_init_read` one slot
+/// twice, moving out of it and then dropping it twice.
 pub struct SpscReceiver<T> {
     pub(super) channel: Arc<SpscChannel<T>>,
+    /// Makes the receiver `!Sync` while leaving it `Send`. See [`SpscSender`].
     _marker: PhantomData<std::cell::Cell<()>>,
 }
 
@@ -256,5 +286,28 @@ impl<T> Drop for SpscSender<T> {
 impl<T> Drop for SpscReceiver<T> {
     fn drop(&mut self) {
         self.channel.closed.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod auto_traits {
+    use super::{SpscReceiver, SpscSender};
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    // Each half may be moved to the thread that owns its role.
+    assert_impl_all!(SpscSender<u64>: Send);
+    assert_impl_all!(SpscReceiver<u64>: Send);
+
+    /// Neither half may be *shared*, which is what keeps the channel SPSC.
+    ///
+    /// Both `send` and `recv` take `&self`, so a `Sync` half could be driven by
+    /// two threads at once: two producers would write the same slot, and two
+    /// consumers would read one slot twice. The `PhantomData<Cell<()>>` on each
+    /// half is the only thing preventing that, and deleting it looks like
+    /// removing an unused field — this assertion is what catches it.
+    #[allow(dead_code)]
+    fn halves_are_not_sync() {
+        assert_not_impl_any!(SpscSender<u64>: Sync);
+        assert_not_impl_any!(SpscReceiver<u64>: Sync);
     }
 }

--- a/moirai-core/src/lib.rs
+++ b/moirai-core/src/lib.rs
@@ -70,8 +70,8 @@ pub use task::{Priority, Task, TaskBuilder, TaskContext, TaskExt, TaskFuture, Ta
 #[cfg(feature = "std")]
 pub use channel::{
     mpmc, spsc, unbounded, unified_channel, unified_channel_with_config, Channel, ChannelConfig,
-    ChannelError, ChannelStatistics, MpmcChannel, MpmcReceiver, MpmcSender, Select, SpscChannel,
-    SpscReceiver, SpscSender, UnifiedReceiver, UnifiedSender,
+    ChannelError, ChannelStatistics, MpmcChannel, MpmcReceiver, MpmcSender, Select, SpscReceiver,
+    SpscSender, UnifiedReceiver, UnifiedSender,
 };
 
 // Re-export CacheAligned from moirai-utils for convenience


### PR DESCRIPTION
Nineteenth increment of the moirai audit, and the first to find undefined behaviour reachable from safe code **across a crate boundary**. Fixes it, with ADR-024 recording the decision since the repair is `[major]`.

## The defect

`moirai-core/src/channel/spsc.rs` is a bounded SPSC ring buffer. Three separately reasonable facts compose into a hole:

- `SpscChannel` is exported **twice** — from `channel/mod.rs` and again from the crate root — with a `pub fn new`.
- It implements the exported `Channel<T>` trait, whose `send`/`recv` take `&self`.
- It carries `unsafe impl<T: Send> Sync`.

So this compiles against the public API, from outside the crate, with no `unsafe`:

```rust
let ch = Arc::new(SpscChannel::<u64>::new(8));
let (a, b) = (Arc::clone(&ch), Arc::clone(&ch));
std::thread::spawn(move || { let _ = a.send(1); });
std::thread::spawn(move || { let _ = b.send(2); });
```

Both producers load the same `head` and write `buffer[head & mask]` — a data race, with one `T` overwritten without being dropped. Two concurrent `recv` calls are worse: both `assume_init_read` the same slot, moving out of it twice and then dropping it twice.

## What is *not* wrong — and is the reason the fix is small

The ring protocol is correct: producer loads `head` relaxed and `tail` acquire, writes the slot, release-stores `head`; monotonic counters make the full check exact without a wasted slot; `Drop` drops exactly `[tail, head)`.

The halves are correct **and deliberately so**. `SpscSender`/`SpscReceiver` are neither `Clone` — so at most one of each exists — nor `Sync`, because each carries a `PhantomData<Cell<()>>` that removes `Sync` while leaving `Send`. A half can be moved to the thread owning its role but never shared. That makes one producer and one consumer a type-level fact rather than a documented convention.

I checked this rather than assuming it, and the check mattered: my first hypothesis was that the sender was equally shareable, which would have implied a much larger redesign. Compiling a probe that shares a `SpscSender` across threads **fails** (`E0277` at `thread::spawn`) — the marker already does its job. Had I skipped that, the ADR would have prescribed a fix while mischaracterising the design it was fixing.

So the bare channel was simply a door around a mechanism that already worked.

## Fix

Seal `SpscChannel` to `pub(crate)` and drop it from both re-export sites. `channel::spsc(capacity)` — already public, already what the crate's own tests use — becomes the only way in.

`Sync` cannot instead be removed from the channel: both halves hold `Arc<SpscChannel<T>>`, and `Arc<T>: Send` requires `T: Send + Sync`, so dropping it would make the halves unsendable and break the supported path. ADR-024 records that constraint and the rejected alternatives (drop the `Channel` impl; runtime producer claim; make it MPMC).

## Verification

Both directions, by compiling the exploit as an integration test — which sees the crate as an external consumer:

- **Before:** builds clean.
- **After:** `error[E0432]: unresolved import moirai_core::channel::SpscChannel`.

The runtime race was not demonstrated and does not need to be: a safe API that *can* reach it is already a defect.

- `cargo check --workspace --all-targets --locked` ✓ — removing a public export is breaking, so every in-workspace user had to surface. None did; the break is external-consumer only.
- `cargo fmt --check`, `clippy --all-targets -- -D warnings`, `nextest` (73/73), warning-denied `cargo doc` ✓
- Every gate run `--locked`, since a manifest changed — CI passes it, and skipping it locally cost a full red cycle on #106.

## Regression guard

`assert_not_impl_any!` on both halves' `Sync`. A positive assertion cannot express this: deleting the `PhantomData<Cell<()>>` only *widens* the impls, so every `assert_impl_all` keeps passing while the race returns. The markers now carry the invariant alone and read like unused fields, so each is documented at its site.

## Migration

`SpscChannel::channel(n)` → `channel::spsc(n)`, returning the same pair. Recorded in the CHANGELOG under a `[breaking]` entry.

Audit progress: nineteen moirai files — twelve sound, seven with defects found and fixed.
