### PR TITLE
feat(core): A borrowed SPSC half pair beside the Arc-backed one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `moirai_core::channel::SpscRing` with `split(&mut self)`, yielding
+  `SpscProducer`/`SpscConsumer` halves that borrow the ring instead of sharing
+  an `Arc`. For pairs living inside a scope — a `thread::scope`, a frame loop, a
+  pipeline stage — the scope already proves the ring outlives the halves, so the
+  refcount enforces statically-checkable lifetimes at runtime cost. The borrowed
+  pair drops that cost: no allocation beyond the ring's buffer, and dropping a
+  half is one store rather than a refcount decrement and a conditional free.
+  Both halves implement `Producer`/`Consumer`, so generic code takes either
+  flavour with no `'static` bound. `spsc(capacity)` is unchanged. See ADR-026.
+
 - `moirai_core::channel::{Producer, Consumer}` — the sending and receiving
   halves of a channel as separate contracts, neither requiring `Sync`. This
   restores generic use of the SPSC halves, which ADR-024 had excluded: they

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1587,3 +1587,104 @@ and receive no longer read the opposite cache line.
    instrument here; the measurement is not claimed until it runs on a quiet
    host, since a memory-bound benchmark taken beside a dozen concurrent
    compiles measures the host, not the queue.
+
+## ADR-026 (2026-07-27): A borrowed SPSC half pair beside the `Arc`-backed one
+
+- Status: Accepted [arch] [minor] · Refs: ADR-024, ADR-025, PR #109
+
+**Intent.** Offer an SPSC pair with no reference counting for the common case
+where both halves live inside a known scope, without giving up the `'static`
+pair that independent threads need.
+
+**Context.** `spsc(capacity)` gives each half an `Arc<SpscChannel<T>>`. That is
+the right shape when producer and consumer threads outlive each other
+arbitrarily. It is pure overhead when both halves are created and dropped
+inside one `thread::scope`, a frame loop, or a pipeline stage: the scope already
+proves the ring outlives the halves, so the refcount is enforcing a lifetime
+relationship the compiler could check statically. The cost is one heap
+allocation for the ring plus an atomic decrement and a conditional deallocation
+per half.
+
+ADR-025's cached-index work made this cheap to add without noticing: the ring
+primitives were changed to take `&self` plus an externally supplied `Cell`, so
+they are already agnostic about whether the caller reached the ring through an
+`Arc` or a borrow. No primitive changed for this ADR.
+
+**Constraints.** One producer and one consumer, statically. No duplication of
+the ring protocol — a second copy of the send/receive logic would be the cloned
+variant the standards forbid. Both flavours must satisfy the same roles, so
+generic code does not fork.
+
+**Options.**
+
+1. *A `'brand`-style generative lifetime* (`GhostCell`-flavoured), giving each
+   split a unique invariant lifetime. Rejected: it delivers exactly the
+   guarantee `&mut self` already delivers here, at the cost of a closure-scoped
+   API (`ring.split(|tx, rx| ...)`) and an invariant-lifetime parameter in every
+   consumer signature. Branding earns its complexity when *several* independent
+   objects must be provably paired; a single ring handing out its own halves is
+   not that case.
+2. *A runtime `split_once` flag* on the ring. Rejected: a runtime check for
+   something the borrow checker already refuses.
+3. *`split(&mut self)` returning halves that borrow the ring.* Chosen. The
+   exclusive borrow is consumed by the returned halves, so a second split, a
+   move, or a drop of the ring is a compile error while either half is alive.
+   This is the same guarantee the `Arc`-backed halves get from being non-`Clone`,
+   obtained from the borrow checker instead of from a refcount.
+
+**Decision.** `SpscRing<T>` owns the ring by value and `split(&mut self)` yields
+`SpscProducer<'_, T>` / `SpscConsumer<'_, T>`, which hold `&SpscChannel<T>` plus
+their own cached index. Both implement the ADR-025 roles, so a function generic
+over `Producer<T>` accepts a borrowed half and an `Arc`-backed one alike, with
+no `'static` bound. `spsc(capacity)` is unchanged.
+
+The module becomes a directory — `spsc/{ring, shared, borrowed}` — because one
+file now holds the ring protocol and two independent wrappers over it, and was
+already at the 500-line target.
+
+**A ring may be re-split once its halves are dropped**, which is what makes it
+reusable across phases without reallocating. Two things make that sound, and
+both are why `split` seeds the caches from the live counters rather than from
+zero:
+
+- `closed` is cleared. A half sets it on drop so its peer stops blocking;
+  leaving it set would fail the next round's first operation.
+- The consumer's cache must satisfy `tail <= cached_head <= head`. A zeroed
+  `cached_head` against a non-zero `tail` breaks the left inequality, and
+  `has_value` then reports a value present in an empty ring and
+  `assume_init_read`s a slot that was never written — undefined behaviour, not
+  merely a wrong value. Seeding from `head` restores the invariant; seeding the
+  producer's cache from `tail` is exact for the same reason.
+
+Reading both counters `Relaxed` in `split` is correct only because `&mut self`
+proves no half exists, so nothing else can be advancing them. That justification
+lives on `SpscChannel::indices`, which is the single place the ring's counters
+are read without synchronization.
+
+**Consequences.** Scope-local pipelines lose the refcount traffic and one
+allocation; dropping a half becomes a single store. The `Arc` pair remains for
+threads with independent lifetimes, so this is additive. The cost is a second
+public pair of half types — accepted because they wrap, rather than duplicate,
+the one ring protocol, and because the roles keep consumers from having to
+choose between them.
+
+**Verification plan.**
+
+1. `resplitting_a_drained_ring_reports_empty` is the falsification test for the
+   seeding rule. Verified to fail on the naive implementation: seeding
+   `cached_head` from zero makes it panic with its own message and then hang the
+   run to nextest's 60s termination — the signature of reading uninitialized
+   memory rather than of a wrong comparison.
+2. `resplitting_preserves_queued_values` covers the other half of re-splitting:
+   values queued in an earlier round survive.
+3. `dropping_a_loaded_ring_drops_each_value_once` counts `Drop` on queued values
+   when the ring dies undrained.
+4. `capacity_is_exact_with_no_sacrificed_slot` asserts all `N` slots are usable,
+   so a future cheaper full-check cannot quietly buy back a slot.
+5. `dropping_the_producer_closes_the_consumer` covers the close handshake a
+   scoped thread depends on to join.
+6. `scoped_threads_move_the_halves_across_the_boundary` runs the real
+   two-thread transfer under `thread::scope` and checks the summed payload.
+7. `auto_traits` asserts `Send` on both halves and, in `halves_are_not_sync`,
+   the absence of `Sync` — the property that keeps the pair SPSC, which no
+   positive assertion can express.

--- a/moirai-core/src/channel/mod.rs
+++ b/moirai-core/src/channel/mod.rs
@@ -31,7 +31,7 @@ pub use hybrid::{HybridChannel, HybridReceiver, HybridSender};
 pub use mpmc::{MpmcChannel, MpmcReceiver, MpmcSender};
 pub use roles::{Consumer, Producer};
 pub use select::{mpmc, spsc, unbounded, Select};
-pub use spsc::{SpscReceiver, SpscSender};
+pub use spsc::{SpscConsumer, SpscProducer, SpscReceiver, SpscRing, SpscSender};
 pub use stats::ChannelStatistics;
 pub use unified::{
     unified_channel, unified_channel_with_config, UnifiedChannel, UnifiedReceiver, UnifiedSender,

--- a/moirai-core/src/channel/spsc/borrowed.rs
+++ b/moirai-core/src/channel/spsc/borrowed.rs
@@ -1,0 +1,439 @@
+//! The borrowed half pair: [`SpscRing::split`].
+//!
+//! [`super::shared`]'s halves each own an `Arc`, which makes them `'static` and
+//! costs one heap allocation for the ring plus an atomic refcount decrement per
+//! half. When both halves live inside a known scope — a `thread::scope`, a
+//! frame loop, a pipeline stage — that reference counting buys nothing, because
+//! the scope already proves the ring outlives them.
+//!
+//! These halves borrow the ring instead. The pair is allocation-free beyond the
+//! ring's own buffer, and dropping a half is a single store rather than a
+//! refcount decrement and a conditional deallocation.
+//!
+//! # Why `split` takes `&mut self`
+//!
+//! The whole SPSC discipline is "one producer, one consumer". Handing out a
+//! second producer would break it, so the exclusive borrow is what forbids a
+//! second [`split`](SpscRing::split) while either half is alive: the returned
+//! halves hold the borrow, so the ring is frozen until both are dropped. No
+//! runtime flag is involved — the same guarantee `Arc`-backed halves get from
+//! being non-`Clone`, obtained here from the borrow checker.
+
+use super::ring::{blocking, SpscChannel};
+use crate::channel::error::{Channel, Result};
+use crate::channel::roles::{Consumer, Producer};
+use std::cell::Cell;
+use std::sync::atomic::Ordering;
+
+/// A bounded SPSC ring buffer owned in place, split into borrowing halves.
+///
+/// ```
+/// use moirai_core::channel::{Consumer, Producer, SpscRing};
+///
+/// let mut ring = SpscRing::<u64>::new(64);
+/// let (tx, rx) = ring.split();
+///
+/// std::thread::scope(|scope| {
+///     scope.spawn(move || {
+///         for value in 0..1000 {
+///             if tx.send(value).is_err() {
+///                 break;
+///             }
+///         }
+///     });
+///
+///     let mut sum = 0;
+///     for _ in 0..1000 {
+///         match rx.recv() {
+///             Ok(value) => sum += value,
+///             Err(_) => break,
+///         }
+///     }
+///     assert_eq!(sum, (0..1000).sum::<u64>());
+/// });
+/// ```
+pub struct SpscRing<T> {
+    channel: SpscChannel<T>,
+}
+
+impl<T: Send> SpscRing<T> {
+    /// Create a ring with at least `capacity` slots, rounded up to a power of
+    /// two so the index-to-slot mapping is a mask rather than a division.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            channel: SpscChannel::new(capacity),
+        }
+    }
+
+    /// Borrow the ring as a producer and a consumer.
+    ///
+    /// Both halves borrow `self`, so the ring cannot be split again, moved, or
+    /// dropped until they are.
+    ///
+    /// A ring may be split again once its previous halves are gone. Values left
+    /// queued by an earlier round stay queued — the counters are not reset —
+    /// which is what makes a ring reusable across phases without reallocating.
+    ///
+    /// Two details make re-splitting sound, and both are why the caches are
+    /// seeded from the live counters rather than from zero:
+    ///
+    /// - `closed` is cleared. A half sets it on drop so its peer stops
+    ///   blocking; leaving it set would make the next round's first operation
+    ///   fail immediately.
+    /// - The consumer's cache must satisfy `tail <= cached_head <= head`. A
+    ///   zeroed `cached_head` against a non-zero `tail` breaks the left side,
+    ///   and `has_value` would then report a value present in an empty ring and
+    ///   read a slot that was never written. Seeding from `head` restores it;
+    ///   seeding the producer's cache from `tail` is exact for the same reason.
+    ///
+    /// Taking `&mut self` is what makes this safe to do without atomics: no
+    /// half exists, so nothing else can be touching either counter.
+    pub fn split(&mut self) -> (SpscProducer<'_, T>, SpscConsumer<'_, T>) {
+        let (head, tail) = self.channel.indices();
+        self.channel.closed.store(false, Ordering::Release);
+
+        (
+            SpscProducer {
+                channel: &self.channel,
+                cached_tail: Cell::new(tail),
+            },
+            SpscConsumer {
+                channel: &self.channel,
+                cached_head: Cell::new(head),
+            },
+        )
+    }
+
+    /// Number of values currently queued.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        let (head, tail) = self.channel.indices();
+        head.wrapping_sub(tail)
+    }
+
+    /// Whether the ring holds no values.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Total slots, after the power-of-two rounding applied at construction.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        Channel::capacity(&self.channel).unwrap_or(0)
+    }
+}
+
+/// The sending half of a borrowed [`SpscRing`].
+///
+/// `Send` so it can be moved into a scoped thread, and not `Sync` for the same
+/// reason as the `Arc`-backed sender: `send` takes `&self`, so two threads
+/// sharing one would claim the same slot.
+pub struct SpscProducer<'ring, T> {
+    channel: &'ring SpscChannel<T>,
+    /// Last known consumer index; see [`SpscSender`](super::SpscSender) for why
+    /// this both saves a cache-line read and keeps the half `!Sync`.
+    cached_tail: Cell<usize>,
+}
+
+impl<T: Send> SpscProducer<'_, T> {
+    /// Send a value, blocking until there is room.
+    ///
+    /// # Errors
+    ///
+    /// [`ChannelError::Closed`](crate::channel::ChannelError::Closed) once the
+    /// consumer half has been dropped.
+    pub fn send(&self, value: T) -> Result<()> {
+        self.channel.send_cached(value, &self.cached_tail)
+    }
+
+    /// Send a value, or report
+    /// [`ChannelError::Full`](crate::channel::ChannelError::Full) rather than
+    /// waiting.
+    ///
+    /// # Errors
+    ///
+    /// `Full` when no slot is free, `Closed` once the consumer has been
+    /// dropped.
+    pub fn try_send(&self, value: T) -> Result<()> {
+        self.channel.try_send_cached(value, &self.cached_tail)
+    }
+}
+
+/// The receiving half of a borrowed [`SpscRing`].
+pub struct SpscConsumer<'ring, T> {
+    channel: &'ring SpscChannel<T>,
+    /// Last known producer index. Mirrors [`SpscProducer::cached_tail`].
+    cached_head: Cell<usize>,
+}
+
+impl<T: Send> SpscConsumer<'_, T> {
+    /// Receive a value, blocking until one arrives.
+    ///
+    /// # Errors
+    ///
+    /// `Closed` once the producer has been dropped and the ring is drained.
+    pub fn recv(&self) -> Result<T> {
+        blocking(|| self.channel.try_recv_cached(&self.cached_head))
+    }
+
+    /// Receive a value, or report
+    /// [`ChannelError::Empty`](crate::channel::ChannelError::Empty) rather than
+    /// waiting.
+    ///
+    /// # Errors
+    ///
+    /// `Empty` when nothing is queued, `Closed` once the producer has been
+    /// dropped and the ring is drained.
+    pub fn try_recv(&self) -> Result<T> {
+        self.channel.try_recv_cached(&self.cached_head)
+    }
+}
+
+impl<T: Send> Producer<T> for SpscProducer<'_, T> {
+    #[inline]
+    fn send(&self, value: T) -> Result<()> {
+        SpscProducer::send(self, value)
+    }
+
+    #[inline]
+    fn try_send(&self, value: T) -> Result<()> {
+        SpscProducer::try_send(self, value)
+    }
+
+    #[inline]
+    fn is_full(&self) -> bool {
+        Channel::is_full(self.channel)
+    }
+
+    #[inline]
+    fn capacity(&self) -> Option<usize> {
+        Channel::capacity(self.channel)
+    }
+}
+
+impl<T: Send> Consumer<T> for SpscConsumer<'_, T> {
+    #[inline]
+    fn recv(&self) -> Result<T> {
+        SpscConsumer::recv(self)
+    }
+
+    #[inline]
+    fn try_recv(&self) -> Result<T> {
+        SpscConsumer::try_recv(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        Channel::is_empty(self.channel)
+    }
+}
+
+impl<T> Drop for SpscProducer<'_, T> {
+    fn drop(&mut self) {
+        self.channel.closed.store(true, Ordering::Release);
+    }
+}
+
+impl<T> Drop for SpscConsumer<'_, T> {
+    fn drop(&mut self) {
+        self.channel.closed.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod auto_traits {
+    use super::{SpscConsumer, SpscProducer, SpscRing};
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    // The ring is handed between threads whole before it is split.
+    assert_impl_all!(SpscRing<u64>: Send, Sync);
+
+    // Each half moves to the scoped thread that owns its role.
+    assert_impl_all!(SpscProducer<'static, u64>: Send);
+    assert_impl_all!(SpscConsumer<'static, u64>: Send);
+
+    /// Neither half may be *shared*, which is what keeps the ring SPSC.
+    ///
+    /// The `Cell` cache is what withholds `Sync`; changing it to a `Sync` type
+    /// would let two threads drive one half and claim the same slot.
+    #[allow(dead_code)]
+    fn halves_are_not_sync() {
+        assert_not_impl_any!(SpscProducer<'static, u64>: Sync);
+        assert_not_impl_any!(SpscConsumer<'static, u64>: Sync);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SpscRing;
+    use crate::channel::roles::{Consumer, Producer};
+    use crate::channel::ChannelError;
+
+    #[test]
+    fn split_halves_transfer_values_in_order() {
+        let mut ring = SpscRing::<u64>::new(4);
+        let (tx, rx) = ring.split();
+
+        assert!(tx.try_send(1).is_ok());
+        assert!(tx.try_send(2).is_ok());
+        assert_eq!(rx.try_recv().expect("a value was sent"), 1);
+        assert_eq!(rx.try_recv().expect("a value was sent"), 2);
+        assert!(matches!(rx.try_recv(), Err(ChannelError::Empty)));
+    }
+
+    #[test]
+    fn capacity_is_exact_with_no_sacrificed_slot() {
+        let mut ring = SpscRing::<u64>::new(4);
+        assert_eq!(ring.capacity(), 4);
+        let (tx, _rx) = ring.split();
+
+        for value in 0..4 {
+            assert!(tx.try_send(value).is_ok(), "slot {value} must be usable");
+        }
+        assert!(matches!(tx.try_send(4), Err(ChannelError::Full)));
+    }
+
+    /// The re-split invariant: a ring reused after its halves drop must not
+    /// invent a value.
+    ///
+    /// Seeding the consumer's cache from zero rather than from `head` breaks
+    /// `tail <= cached_head`, and `has_value` then reports a value present in
+    /// an empty ring and reads a slot that was never written. This is the test
+    /// that fails if `split` stops reading the live counters.
+    #[test]
+    fn resplitting_a_drained_ring_reports_empty() {
+        let mut ring = SpscRing::<u64>::new(4);
+        {
+            let (tx, rx) = ring.split();
+            for value in 0..3 {
+                tx.try_send(value).expect("capacity is 4");
+            }
+            for expected in 0..3 {
+                assert_eq!(rx.try_recv().expect("three were sent"), expected);
+            }
+        }
+
+        // Counters are now at 3, not 0, and the ring is empty.
+        assert!(ring.is_empty());
+        let (_tx, rx) = ring.split();
+        assert!(
+            matches!(rx.try_recv(), Err(ChannelError::Empty)),
+            "a drained ring must report empty, not read an unwritten slot"
+        );
+    }
+
+    #[test]
+    fn resplitting_preserves_queued_values() {
+        let mut ring = SpscRing::<u64>::new(8);
+        {
+            let (tx, _rx) = ring.split();
+            tx.try_send(7).expect("capacity is 8");
+            tx.try_send(8).expect("capacity is 8");
+        }
+        assert_eq!(ring.len(), 2);
+
+        let (_tx, rx) = ring.split();
+        assert_eq!(rx.try_recv().expect("queued across the split"), 7);
+        assert_eq!(rx.try_recv().expect("queued across the split"), 8);
+    }
+
+    /// Dropping a half must release a peer blocked in the other, or a scoped
+    /// thread would never join.
+    #[test]
+    fn dropping_the_producer_closes_the_consumer() {
+        let mut ring = SpscRing::<u64>::new(4);
+        let (tx, rx) = ring.split();
+        tx.try_send(1).expect("capacity is 4");
+        drop(tx);
+
+        assert_eq!(rx.recv().expect("the queued value survives closure"), 1);
+        assert!(matches!(rx.recv(), Err(ChannelError::Closed)));
+    }
+
+    /// The point of the roles: borrowed halves are usable by the same generic
+    /// code as the `Arc`-backed ones, with no `'static` bound in sight.
+    #[test]
+    fn borrowed_halves_satisfy_the_roles() {
+        fn drain_into<P: Producer<u64>>(producer: &P, values: &[u64]) -> usize {
+            values
+                .iter()
+                .filter(|v| producer.try_send(**v).is_ok())
+                .count()
+        }
+        fn take_all<C: Consumer<u64>>(consumer: &C, limit: usize) -> Vec<u64> {
+            (0..limit)
+                .filter_map(|_| consumer.try_recv().ok())
+                .collect()
+        }
+
+        let mut ring = SpscRing::<u64>::new(8);
+        let (tx, rx) = ring.split();
+
+        assert_eq!(drain_into(&tx, &[1, 2, 3]), 3);
+        assert_eq!(Producer::capacity(&tx), Some(8));
+        assert!(!Consumer::is_empty(&rx));
+        assert_eq!(take_all(&rx, 8), vec![1, 2, 3]);
+    }
+
+    /// Values left in a ring that is dropped without being drained must still
+    /// be dropped exactly once.
+    #[test]
+    fn dropping_a_loaded_ring_drops_each_value_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        struct Counted(Arc<AtomicUsize>);
+        impl Drop for Counted {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let drops = Arc::new(AtomicUsize::new(0));
+        {
+            let mut ring = SpscRing::<Counted>::new(4);
+            let (tx, _rx) = ring.split();
+            for _ in 0..3 {
+                tx.try_send(Counted(Arc::clone(&drops)))
+                    .expect("capacity is 4");
+            }
+        }
+
+        assert_eq!(
+            drops.load(Ordering::Relaxed),
+            3,
+            "every queued value is dropped exactly once with the ring"
+        );
+    }
+
+    #[test]
+    fn scoped_threads_move_the_halves_across_the_boundary() {
+        const COUNT: u64 = 10_000;
+
+        let mut ring = SpscRing::<u64>::new(64);
+        let (tx, rx) = ring.split();
+
+        let sum = std::thread::scope(|scope| {
+            scope.spawn(move || {
+                for value in 0..COUNT {
+                    if tx.send(value).is_err() {
+                        break;
+                    }
+                }
+            });
+
+            let mut sum = 0_u64;
+            for _ in 0..COUNT {
+                match rx.recv() {
+                    Ok(value) => sum = sum.wrapping_add(value),
+                    Err(_) => break,
+                }
+            }
+            sum
+        });
+
+        assert_eq!(sum, (0..COUNT).sum::<u64>());
+    }
+}

--- a/moirai-core/src/channel/spsc/mod.rs
+++ b/moirai-core/src/channel/spsc/mod.rs
@@ -1,0 +1,26 @@
+//! Lock-free single-producer/single-consumer channel.
+//!
+//! One bounded ring with two ways to hand out its halves:
+//!
+//! - [`spsc(capacity)`](crate::channel::spsc()) returns `'static` halves backed
+//!   by an `Arc`, for producer and consumer threads with independent lifetimes.
+//! - [`SpscRing::split`] borrows a ring you own, for halves that live inside a
+//!   scope. No `Arc`, so no refcount traffic and one fewer allocation.
+//!
+//! Both flavours drive the same primitives and implement the same
+//! [`Producer`](crate::channel::Producer) and
+//! [`Consumer`](crate::channel::Consumer) roles, so generic code accepts either
+//! without a `'static` bound.
+//!
+//! Neither half is `Clone` or `Sync`, which is what keeps the channel
+//! single-producer/single-consumer; the ring type itself stays crate-private
+//! for the same reason (ADR-024, ADR-026).
+
+mod borrowed;
+mod ring;
+mod shared;
+
+pub use borrowed::{SpscConsumer, SpscProducer, SpscRing};
+pub use shared::{SpscReceiver, SpscSender};
+
+pub(crate) use ring::SpscChannel;

--- a/moirai-core/src/channel/spsc/ring.rs
+++ b/moirai-core/src/channel/spsc/ring.rs
@@ -1,12 +1,16 @@
-//! Lock-free Single Producer Single Consumer channel.
+//! The bounded ring itself: storage, the two counters, and the cached-index
+//! primitives both half-pair flavours drive.
 //!
-//! Optimized for low latency with zero-copy semantics.
+//! Nothing here decides *who* may send or receive. That is the job of the
+//! wrappers in [`shared`](super::shared) and [`borrowed`](super::borrowed),
+//! which is why [`SpscChannel`] stays crate-private: its methods take `&self`
+//! and its `Sync` impl lets `&SpscChannel` cross threads, so exposing it would
+//! let safe code drive two producers into one slot (ADR-024).
 
-use super::error::{CacheAligned, Channel, ChannelError, Result};
+use crate::channel::error::{CacheAligned, Channel, ChannelError, Result};
 use std::cell::{Cell, UnsafeCell};
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
 
 /// Exponential-backoff spin rounds (`1 << round` spin-loop hints per round,
 /// ~63 total hints) before a blocked send/recv falls back to
@@ -31,8 +35,11 @@ pub(crate) struct SpscChannel<T> {
     head: CacheAligned<AtomicUsize>,
     /// Consumer position (cache-aligned)
     tail: CacheAligned<AtomicUsize>,
-    /// Channel state
-    closed: AtomicBool,
+    /// Channel state.
+    ///
+    /// Written by whichever half drops first, so a peer blocked in `send` or
+    /// `recv` stops waiting; read on every operation.
+    pub(super) closed: AtomicBool,
 }
 
 // SAFETY: the buffer is only ever touched by one producer and one consumer,
@@ -65,19 +72,22 @@ impl<T> SpscChannel<T> {
             closed: AtomicBool::new(false),
         }
     }
+}
 
-    /// Create a channel pair (sender, receiver) for ergonomic usage
-    pub fn channel(capacity: usize) -> (SpscSender<T>, SpscReceiver<T>) {
-        let channel = Arc::new(Self::new(capacity));
+impl<T> SpscChannel<T> {
+    /// The producer and consumer counters, in that order, read without
+    /// synchronization.
+    ///
+    /// `Relaxed` is correct only because every caller holds the ring
+    /// exclusively: [`SpscRing`](super::SpscRing)'s methods take `&self` or
+    /// `&mut self`, and its halves borrow it, so no half can exist — and
+    /// therefore no other thread can be advancing either counter — while this
+    /// runs. Reading these from a live half would need the acquire loads the
+    /// send and receive paths use.
+    pub(super) fn indices(&self) -> (usize, usize) {
         (
-            SpscSender {
-                channel: channel.clone(),
-                cached_tail: Cell::new(0),
-            },
-            SpscReceiver {
-                channel,
-                cached_head: Cell::new(0),
-            },
+            self.head.0.load(Ordering::Relaxed),
+            self.tail.0.load(Ordering::Relaxed),
         )
     }
 }
@@ -111,7 +121,7 @@ fn back_off(spin: &mut usize) {
 
 /// Retry `attempt` on the spin-then-yield schedule until it resolves to
 /// something other than a transiently full or empty queue.
-fn blocking<F, R>(mut attempt: F) -> Result<R>
+pub(super) fn blocking<F, R>(mut attempt: F) -> Result<R>
 where
     F: FnMut() -> Result<R>,
 {
@@ -134,7 +144,7 @@ impl<T: Send> SpscChannel<T> {
     /// this may take the slow path unnecessarily but can never report space that
     /// does not exist. That one-sidedness is what makes the cache sound.
     #[inline]
-    fn has_room(&self, head: usize, cached_tail: &Cell<usize>) -> bool {
+    pub(super) fn has_room(&self, head: usize, cached_tail: &Cell<usize>) -> bool {
         if head.wrapping_sub(cached_tail.get()) < self.buffer.len() {
             return true;
         }
@@ -149,7 +159,7 @@ impl<T: Send> SpscChannel<T> {
     /// index. Mirrors [`Self::has_room`]: a stale cache understates what is
     /// queued, so it can cost an extra load but never invent an element.
     #[inline]
-    fn has_value(&self, tail: usize, cached_head: &Cell<usize>) -> bool {
+    pub(super) fn has_value(&self, tail: usize, cached_head: &Cell<usize>) -> bool {
         if tail != cached_head.get() {
             return true;
         }
@@ -158,7 +168,7 @@ impl<T: Send> SpscChannel<T> {
         tail != head
     }
 
-    fn try_send_cached(&self, value: T, cached_tail: &Cell<usize>) -> Result<()> {
+    pub(super) fn try_send_cached(&self, value: T, cached_tail: &Cell<usize>) -> Result<()> {
         if self.closed.load(Ordering::Acquire) {
             return Err(ChannelError::Closed);
         }
@@ -179,7 +189,7 @@ impl<T: Send> SpscChannel<T> {
         Ok(())
     }
 
-    fn try_recv_cached(&self, cached_head: &Cell<usize>) -> Result<T> {
+    pub(super) fn try_recv_cached(&self, cached_head: &Cell<usize>) -> Result<T> {
         let tail = self.tail.0.load(Ordering::Relaxed);
 
         if !self.has_value(tail, cached_head) {
@@ -214,7 +224,7 @@ impl<T: Send> SpscChannel<T> {
     /// `value` must survive a failed attempt: `try_send_cached` takes it by
     /// value, so a closure would move it on the first iteration. Here it stays
     /// owned by this frame and is moved exactly once, when a slot is claimed.
-    fn send_cached(&self, value: T, cached_tail: &Cell<usize>) -> Result<()> {
+    pub(super) fn send_cached(&self, value: T, cached_tail: &Cell<usize>) -> Result<()> {
         let mut spin = 0;
         loop {
             if self.closed.load(Ordering::Acquire) {
@@ -364,137 +374,5 @@ impl<T: Send> Channel<T> for SpscChannel<T> {
 
     fn capacity(&self) -> Option<usize> {
         Some(self.buffer.len())
-    }
-}
-
-/// Sender half of SPSC channel.
-///
-/// The single-producer half of the pair: not `Clone`, so only one exists, and
-/// not `Sync`, so it cannot be shared while it exists.
-pub struct SpscSender<T> {
-    pub(super) channel: Arc<SpscChannel<T>>,
-    /// Last known consumer index, and the reason the sender is `!Sync`.
-    ///
-    /// Reading the real `tail` on every send touches the consumer's cache line
-    /// each time, which dominates the cost of a queue that is otherwise two
-    /// loads and a store. Consulting this first means a producer that is not
-    /// hitting a full queue never reads the consumer's line at all.
-    ///
-    /// It doubles as the marker keeping the sender unshareable: `send` takes
-    /// `&self`, so a `Sync` sender could be driven by two threads at once, both
-    /// claiming the same slot. `Cell` is `Send` but not `Sync`, which permits
-    /// moving the sender to another thread while forbidding sharing it.
-    /// Replacing it with something `Sync` reopens that race, and
-    /// `halves_are_not_sync` fails if it happens.
-    cached_tail: Cell<usize>,
-}
-
-impl<T: Send> SpscSender<T> {
-    /// Send a value through the channel, blocking until there is room.
-    pub fn send(&self, value: T) -> Result<()> {
-        self.channel.send_cached(value, &self.cached_tail)
-    }
-
-    /// Try to send a value without blocking.
-    pub fn try_send(&self, value: T) -> Result<()> {
-        self.channel.try_send_cached(value, &self.cached_tail)
-    }
-}
-
-/// Receiver half of SPSC channel.
-///
-/// The single-consumer half of the pair, `!Sync` for the same reason as
-/// [`SpscSender`] — two shared receivers would `assume_init_read` one slot
-/// twice, moving out of it and then dropping it twice.
-pub struct SpscReceiver<T> {
-    pub(super) channel: Arc<SpscChannel<T>>,
-    /// Last known producer index, and the reason the receiver is `!Sync`.
-    /// Mirrors `SpscSender::cached_tail` in both roles.
-    cached_head: Cell<usize>,
-}
-
-impl<T: Send> SpscReceiver<T> {
-    /// Receive a value from the channel, blocking until one arrives.
-    pub fn recv(&self) -> Result<T> {
-        blocking(|| self.channel.try_recv_cached(&self.cached_head))
-    }
-
-    /// Try to receive a value without blocking.
-    pub fn try_recv(&self) -> Result<T> {
-        self.channel.try_recv_cached(&self.cached_head)
-    }
-}
-
-impl<T: Send> crate::channel::roles::Producer<T> for SpscSender<T> {
-    #[inline]
-    fn send(&self, value: T) -> Result<()> {
-        SpscSender::send(self, value)
-    }
-
-    #[inline]
-    fn try_send(&self, value: T) -> Result<()> {
-        SpscSender::try_send(self, value)
-    }
-
-    #[inline]
-    fn is_full(&self) -> bool {
-        Channel::is_full(&*self.channel)
-    }
-
-    #[inline]
-    fn capacity(&self) -> Option<usize> {
-        Channel::capacity(&*self.channel)
-    }
-}
-
-impl<T: Send> crate::channel::roles::Consumer<T> for SpscReceiver<T> {
-    #[inline]
-    fn recv(&self) -> Result<T> {
-        SpscReceiver::recv(self)
-    }
-
-    #[inline]
-    fn try_recv(&self) -> Result<T> {
-        SpscReceiver::try_recv(self)
-    }
-
-    #[inline]
-    fn is_empty(&self) -> bool {
-        Channel::is_empty(&*self.channel)
-    }
-}
-
-impl<T> Drop for SpscSender<T> {
-    fn drop(&mut self) {
-        self.channel.closed.store(true, Ordering::Release);
-    }
-}
-
-impl<T> Drop for SpscReceiver<T> {
-    fn drop(&mut self) {
-        self.channel.closed.store(true, Ordering::Release);
-    }
-}
-
-#[cfg(test)]
-mod auto_traits {
-    use super::{SpscReceiver, SpscSender};
-    use static_assertions::{assert_impl_all, assert_not_impl_any};
-
-    // Each half may be moved to the thread that owns its role.
-    assert_impl_all!(SpscSender<u64>: Send);
-    assert_impl_all!(SpscReceiver<u64>: Send);
-
-    /// Neither half may be *shared*, which is what keeps the channel SPSC.
-    ///
-    /// Both `send` and `recv` take `&self`, so a `Sync` half could be driven by
-    /// two threads at once: two producers would write the same slot, and two
-    /// consumers would read one slot twice. The `PhantomData<Cell<()>>` on each
-    /// half is the only thing preventing that, and deleting it looks like
-    /// removing an unused field — this assertion is what catches it.
-    #[allow(dead_code)]
-    fn halves_are_not_sync() {
-        assert_not_impl_any!(SpscSender<u64>: Sync);
-        assert_not_impl_any!(SpscReceiver<u64>: Sync);
     }
 }

--- a/moirai-core/src/channel/spsc/shared.rs
+++ b/moirai-core/src/channel/spsc/shared.rs
@@ -1,0 +1,162 @@
+//! The `Arc`-backed half pair: `spsc(capacity)`.
+//!
+//! Each half owns a reference-counted handle to the ring, so both are
+//! `'static` and can be moved into freshly spawned threads. The cost is one
+//! allocation for the ring plus an atomic refcount decrement per half at
+//! drop; [`borrowed`](super::borrowed) trades that for a scope.
+
+use super::ring::{blocking, SpscChannel};
+use crate::channel::error::{Channel, Result};
+use crate::channel::roles::{Consumer, Producer};
+use std::cell::Cell;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+impl<T> SpscChannel<T> {
+    /// Create a channel pair (sender, receiver) for ergonomic usage
+    pub fn channel(capacity: usize) -> (SpscSender<T>, SpscReceiver<T>) {
+        let channel = Arc::new(Self::new(capacity));
+        (
+            SpscSender {
+                channel: channel.clone(),
+                cached_tail: Cell::new(0),
+            },
+            SpscReceiver {
+                channel,
+                cached_head: Cell::new(0),
+            },
+        )
+    }
+}
+
+/// Sender half of SPSC channel.
+///
+/// The single-producer half of the pair: not `Clone`, so only one exists, and
+/// not `Sync`, so it cannot be shared while it exists.
+pub struct SpscSender<T> {
+    pub(super) channel: Arc<SpscChannel<T>>,
+    /// Last known consumer index, and the reason the sender is `!Sync`.
+    ///
+    /// Reading the real `tail` on every send touches the consumer's cache line
+    /// each time, which dominates the cost of a queue that is otherwise two
+    /// loads and a store. Consulting this first means a producer that is not
+    /// hitting a full queue never reads the consumer's line at all.
+    ///
+    /// It doubles as the marker keeping the sender unshareable: `send` takes
+    /// `&self`, so a `Sync` sender could be driven by two threads at once, both
+    /// claiming the same slot. `Cell` is `Send` but not `Sync`, which permits
+    /// moving the sender to another thread while forbidding sharing it.
+    /// Replacing it with something `Sync` reopens that race, and
+    /// `halves_are_not_sync` fails if it happens.
+    cached_tail: Cell<usize>,
+}
+
+impl<T: Send> SpscSender<T> {
+    /// Send a value through the channel, blocking until there is room.
+    pub fn send(&self, value: T) -> Result<()> {
+        self.channel.send_cached(value, &self.cached_tail)
+    }
+
+    /// Try to send a value without blocking.
+    pub fn try_send(&self, value: T) -> Result<()> {
+        self.channel.try_send_cached(value, &self.cached_tail)
+    }
+}
+
+/// Receiver half of SPSC channel.
+///
+/// The single-consumer half of the pair, `!Sync` for the same reason as
+/// [`SpscSender`] — two shared receivers would `assume_init_read` one slot
+/// twice, moving out of it and then dropping it twice.
+pub struct SpscReceiver<T> {
+    pub(super) channel: Arc<SpscChannel<T>>,
+    /// Last known producer index, and the reason the receiver is `!Sync`.
+    /// Mirrors `SpscSender::cached_tail` in both roles.
+    cached_head: Cell<usize>,
+}
+
+impl<T: Send> SpscReceiver<T> {
+    /// Receive a value from the channel, blocking until one arrives.
+    pub fn recv(&self) -> Result<T> {
+        blocking(|| self.channel.try_recv_cached(&self.cached_head))
+    }
+
+    /// Try to receive a value without blocking.
+    pub fn try_recv(&self) -> Result<T> {
+        self.channel.try_recv_cached(&self.cached_head)
+    }
+}
+
+impl<T: Send> Producer<T> for SpscSender<T> {
+    #[inline]
+    fn send(&self, value: T) -> Result<()> {
+        SpscSender::send(self, value)
+    }
+
+    #[inline]
+    fn try_send(&self, value: T) -> Result<()> {
+        SpscSender::try_send(self, value)
+    }
+
+    #[inline]
+    fn is_full(&self) -> bool {
+        Channel::is_full(&*self.channel)
+    }
+
+    #[inline]
+    fn capacity(&self) -> Option<usize> {
+        Channel::capacity(&*self.channel)
+    }
+}
+
+impl<T: Send> Consumer<T> for SpscReceiver<T> {
+    #[inline]
+    fn recv(&self) -> Result<T> {
+        SpscReceiver::recv(self)
+    }
+
+    #[inline]
+    fn try_recv(&self) -> Result<T> {
+        SpscReceiver::try_recv(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        Channel::is_empty(&*self.channel)
+    }
+}
+
+impl<T> Drop for SpscSender<T> {
+    fn drop(&mut self) {
+        self.channel.closed.store(true, Ordering::Release);
+    }
+}
+
+impl<T> Drop for SpscReceiver<T> {
+    fn drop(&mut self) {
+        self.channel.closed.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod auto_traits {
+    use super::{SpscReceiver, SpscSender};
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    // Each half may be moved to the thread that owns its role.
+    assert_impl_all!(SpscSender<u64>: Send);
+    assert_impl_all!(SpscReceiver<u64>: Send);
+
+    /// Neither half may be *shared*, which is what keeps the channel SPSC.
+    ///
+    /// Both `send` and `recv` take `&self`, so a `Sync` half could be driven by
+    /// two threads at once: two producers would write the same slot, and two
+    /// consumers would read one slot twice. The `Cell` cache on each half is
+    /// what prevents it, so changing that field to a `Sync` type would reopen
+    /// the race — this assertion is what catches it.
+    #[allow(dead_code)]
+    fn halves_are_not_sync() {
+        assert_not_impl_any!(SpscSender<u64>: Sync);
+        assert_not_impl_any!(SpscReceiver<u64>: Sync);
+    }
+}

--- a/moirai-core/src/lib.rs
+++ b/moirai-core/src/lib.rs
@@ -71,7 +71,8 @@ pub use task::{Priority, Task, TaskBuilder, TaskContext, TaskExt, TaskFuture, Ta
 pub use channel::{
     mpmc, spsc, unbounded, unified_channel, unified_channel_with_config, Channel, ChannelConfig,
     ChannelError, ChannelStatistics, Consumer, MpmcChannel, MpmcReceiver, MpmcSender, Producer,
-    Select, SpscReceiver, SpscSender, UnifiedReceiver, UnifiedSender,
+    Select, SpscConsumer, SpscProducer, SpscReceiver, SpscRing, SpscSender, UnifiedReceiver,
+    UnifiedSender,
 };
 
 // Re-export CacheAligned from moirai-utils for convenience
@@ -102,6 +103,6 @@ pub mod prelude {
     #[cfg(feature = "std")]
     pub use crate::{
         mpmc, spsc, unbounded, Channel, ChannelError, Consumer, MpmcReceiver, MpmcSender, Producer,
-        SpscReceiver, SpscSender,
+        SpscConsumer, SpscProducer, SpscReceiver, SpscRing, SpscSender,
     };
 }


### PR DESCRIPTION
Completes the SPSC work started in #109: an allocation-free pair for the common case where both halves live inside a scope.

## Why

`spsc(capacity)` gives each half an `Arc<SpscChannel<T>>`. That is the right shape when producer and consumer threads outlive each other arbitrarily. It is pure overhead when both halves are created and dropped inside one `thread::scope`, frame loop, or pipeline stage — the scope already proves the ring outlives the halves, so the refcount is enforcing at runtime a lifetime relationship the compiler can check statically. The cost is a heap allocation for the ring plus an atomic decrement and a conditional free per half.

## What

`SpscRing<T>` owns the ring by value; `split(&mut self)` yields `SpscProducer<'_, T>` / `SpscConsumer<'_, T>` holding `&SpscChannel<T>` plus their own cached index. Both implement the #109 `Producer`/`Consumer` roles, so a function generic over `Producer<T>` takes a borrowed half and an `Arc`-backed one alike, with no `'static` bound. `spsc(capacity)` is unchanged.

The exclusive borrow is the enforcement: it is consumed by the returned halves, so a second `split`, a move, or a drop of the ring is a compile error while either half is alive — the same guarantee the `Arc` halves get from being non-`Clone`, obtained from the borrow checker instead of a refcount.

**A generative `'brand` was considered and rejected.** It delivers exactly the guarantee `&mut self` already delivers here, at the cost of a closure-scoped API (`ring.split(|tx, rx| ...)`) and an invariant lifetime parameter in every consumer signature. Branding earns its complexity when several independent objects must be provably paired; one ring handing out its own halves is not that case.

**No protocol duplication.** #109's cached-index work moved the ring primitives to `&self` plus an externally supplied `Cell`, which left them agnostic about whether the caller arrived via an `Arc` or a borrow. No primitive changed for this PR.

## The subtle part: re-splitting

A ring may be split again once its halves drop, which is what makes it reusable across phases without reallocating. `split` seeds the caches from the **live** counters, not from zero, because the consumer's cache must satisfy `tail <= cached_head <= head`. A zeroed `cached_head` against a non-zero `tail` breaks the left inequality; `has_value` then reports a value present in an empty ring and `assume_init_read`s a slot that was never written — undefined behaviour, not a wrong value.

I verified this rather than asserting it. Seeding `cached_head` from zero makes `resplitting_a_drained_ring_reports_empty` panic with its own message **and then hang the run to nextest's 60s termination bound** — the signature of reading uninitialized memory. The test is not tautological.

Reading both counters `Relaxed` in `split` is sound only because `&mut self` proves no half exists. That justification lives on `SpscChannel::indices`, the one place the counters are read without synchronization.

## Structure

`spsc.rs` becomes `spsc/{ring, shared, borrowed}` — it held the ring protocol plus two independent wrappers and was already at the 500-line target. Shown as a rename, so the protocol diff stays reviewable.

## Verification

- `fmt --check`; `clippy --workspace --all-targets -D warnings` clean
- `nextest --workspace`: **778/778**; doctests 3/3; `RUSTDOCFLAGS=-D warnings cargo doc` clean
- New tests cover: exact capacity with no sacrificed slot; re-split reporting empty (the falsification test above); re-split preserving queued values; drop-exactly-once for values left in an undrained ring; the close handshake a scoped thread needs to join; a real two-thread `thread::scope` transfer; and `Send` plus the *absence* of `Sync` on both halves

Refs: ADR-026, ADR-025, #109

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces an allocation-free borrowed SPSC channel pair (`SpscRing::split`) alongside the existing `Arc`-backed pair. The borrowed variant uses `&mut self` split semantics to yield `SpscProducer`/`SpscConsumer` halves that borrow the ring instead of reference-counting it, eliminating heap allocation and refcount overhead for use cases where both halves live within a known scope (such as `thread::scope`, frame loops, or pipeline stages). Both flavours implement the same `Producer`/`Consumer` traits without requiring `'static` bounds, allowing generic code to work with either variant. The implementation includes careful handling of re-splitting semantics where counters must be seeded from live values rather than zero to maintain safety invariants. The module is restructured from a single file into `spsc/{ring, shared, borrowed}` to separate concerns.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `moirai-core/src/channel/spsc/mod.rs` |
| 2 | `moirai-core/src/channel/spsc/ring.rs` |
| 3 | `moirai-core/src/channel/spsc/borrowed.rs` |
| 4 | `moirai-core/src/channel/spsc/shared.rs` |
| 5 | `moirai-core/src/channel/mod.rs` |
| 6 | `moirai-core/src/lib.rs` |
| 7 | `CHANGELOG.md` |
| 8 | `docs/adr.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->