### PR TITLE
build(deps): Adopt Mnemosyne package identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bind the `themis` crate alias to the renamed `themis-topology` package so
   fresh Git dependency resolution follows the provider identity.
+- Bind the `mnemosyne` and `mnemosyne_core` crate aliases to packages
+  `mnemosyne-memory` and `mnemosyne-memory-core` while preserving Rust imports.
 
 ### Breaking
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -2,6 +2,13 @@
 
 **Target**: Unreleased
 
+## MOI-MNEMOSYNE-PACKAGE-1 — package identity [patch] — complete
+
+- Owner: Codex on `codex/moirai-mnemosyne-package`.
+- [x] Bind the facade and core aliases to their `mnemosyne-memory` package
+      identities.
+- [x] Refresh dependency resolution and pass the focused core check.
+
 ## MOI-THEMIS-PACKAGE-1 — package identity [patch] — complete
 
 - Owner: Codex on `codex/moirai-themis-package`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,88 +1096,88 @@ dependencies = [
 ]
 
 [[package]]
-name = "mnemosyne"
-version = "0.6.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
-dependencies = [
- "mnemosyne-arena",
- "mnemosyne-backend",
- "mnemosyne-core",
- "mnemosyne-decay",
- "mnemosyne-hardened",
- "mnemosyne-local",
- "mnemosyne-prof",
-]
-
-[[package]]
 name = "mnemosyne-arena"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
 dependencies = [
  "mnemosyne-backend",
- "mnemosyne-core",
+ "mnemosyne-memory-core",
  "themis-topology",
 ]
 
 [[package]]
 name = "mnemosyne-backend"
 version = "0.5.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
 dependencies = [
- "mnemosyne-core",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
 name = "mnemosyne-build-util"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
-
-[[package]]
-name = "mnemosyne-core"
-version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
 
 [[package]]
 name = "mnemosyne-decay"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
 dependencies = [
  "mnemosyne-arena",
  "mnemosyne-backend",
- "mnemosyne-core",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
 name = "mnemosyne-hardened"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
 dependencies = [
- "mnemosyne-core",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
 name = "mnemosyne-local"
 version = "0.3.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
 dependencies = [
  "melinoe",
  "mnemosyne-arena",
  "mnemosyne-backend",
  "mnemosyne-build-util",
- "mnemosyne-core",
  "mnemosyne-decay",
+ "mnemosyne-memory-core",
  "mnemosyne-prof",
  "themis-topology",
 ]
 
 [[package]]
+name = "mnemosyne-memory"
+version = "0.6.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
+dependencies = [
+ "mnemosyne-arena",
+ "mnemosyne-backend",
+ "mnemosyne-decay",
+ "mnemosyne-hardened",
+ "mnemosyne-local",
+ "mnemosyne-memory-core",
+ "mnemosyne-prof",
+]
+
+[[package]]
+name = "mnemosyne-memory-core"
+version = "0.2.0"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
+
+[[package]]
 name = "mnemosyne-prof"
 version = "0.2.0"
-source = "git+https://github.com/ryancinsight/Mnemosyne.git#0e57030076e563504c5ebfe4de13a7d094fc8d96"
+source = "git+https://github.com/ryancinsight/Mnemosyne.git#be4aa64d057eb8471b24c9210e77396bdce143cf"
 dependencies = [
  "backtrace",
  "mnemosyne-build-util",
- "mnemosyne-core",
+ "mnemosyne-memory-core",
 ]
 
 [[package]]
@@ -1188,7 +1188,7 @@ dependencies = [
  "fastrand",
  "futures",
  "melinoe",
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai-async",
  "moirai-core",
  "moirai-executor",
@@ -1242,7 +1242,7 @@ dependencies = [
  "crossbeam",
  "futures",
  "libc",
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai",
  "moirai-async",
  "moirai-core",
@@ -1269,7 +1269,7 @@ dependencies = [
  "bytemuck",
  "criterion",
  "libc",
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai-utils",
  "proptest",
  "static_assertions",
@@ -1282,7 +1282,7 @@ dependencies = [
  "criterion",
  "loom",
  "melinoe",
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai-core",
  "moirai-pal",
  "moirai-scheduler",
@@ -1297,7 +1297,7 @@ dependencies = [
  "bytemuck",
  "criterion",
  "futures",
- "mnemosyne-core",
+ "mnemosyne-memory-core",
  "moirai-core",
  "moirai-executor",
  "moirai-utils",
@@ -1391,7 +1391,7 @@ version = "0.4.0"
 dependencies = [
  "criterion",
  "loom",
- "mnemosyne",
+ "mnemosyne-memory",
  "moirai-core",
  "moirai-utils",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ moirai-gpu = { path = "moirai-gpu", version = "0.4.0" }
 melinoe = { git = "https://github.com/ryancinsight/melinoe.git", version = "0.9.0", default-features = false }
 themis = { package = "themis-topology", git = "https://github.com/ryancinsight/themis", version = "0.10.1", default-features = false, features = ["std"] }
 # Kernel resource budget vocabulary for the GPU occupancy planner (atlas ADR 0002).
-mnemosyne-core = { git = "https://github.com/ryancinsight/Mnemosyne.git", version = "0.2.0", package = "mnemosyne-core", default-features = false }
-mnemosyne = { git = "https://github.com/ryancinsight/Mnemosyne.git", version = "0.6.0", default-features = false }
+mnemosyne-core = { git = "https://github.com/ryancinsight/Mnemosyne.git", version = "0.2.0", package = "mnemosyne-memory-core", default-features = false }
+mnemosyne = { git = "https://github.com/ryancinsight/Mnemosyne.git", version = "0.6.0", package = "mnemosyne-memory", default-features = false }
 
 # Network stack (ADR-015): sans-I/O, runtime-agnostic, NOT tokio-coupled.
 # `ring` crypto provider (no aws-lc-rs NASM/cmake toolchain requirement on Windows).


### PR DESCRIPTION
Binds existing Rust crate aliases to the collision-free mnemosyne-memory package identities and refreshes the locked Git revision. Verification: cargo check --locked -p moirai-core against Mnemosyne be4aa64d and git diff --check.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the Rust dependency configuration to bind existing crate aliases `mnemosyne` and `mnemosyne_core` to their renamed collision-free package identities `mnemosyne-memory` and `mnemosyne-memory-core` respectively. The changes preserve existing Rust imports while updating the package references in dependency declarations and refreshing the locked Git revision from `0e570300` to `be4aa64d`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Cargo.toml` |
| 2 | `Cargo.lock` |
| 3 | `CHANGELOG.md` |
| 4 | `CHECKLIST.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->