### PR TITLE
ci(python): Bump atlas-ref to current atlas head for provider graph checkout

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -20,12 +20,12 @@ jobs:
       attestations: write
       contents: write
       id-token: write
-    uses: ryancinsight/atlas/.github/workflows/python-wheels.yml@b20a1b494672759c39503daf5687b1de2062f9a0
+    uses: ryancinsight/atlas/.github/workflows/python-wheels.yml@1a7cdcafce845bfa625e4917436c22566ad3486
     with:
       distribution: moirai-python
       import-name: moirai_python
       manifest-path: moirai-python/Cargo.toml
-      atlas-ref: b20a1b494672759c39503daf5687b1de2062f9a0
+      atlas-ref: 1a7cdcafce845bfa625e4917436c22566ad3486
       tag-prefix: moirai-python-v
       abi3: false
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'


### PR DESCRIPTION
Advances the shared python-wheels.yml caller and atlas-ref from the stale b20a1b49/777cf325 to 1a7cdca, so the wheel build checks out the current provider graph (leto 0.41.0, aequitas 0.2.0).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the GitHub Actions workflow to use the latest version of the shared python-wheels workflow and atlas reference. The changes bump both the workflow reference and the `atlas-ref` parameter from an older commit (`b20a1b49`/`777cf325`) to a newer commit (`1a7cdca`), which brings in the current provider graph dependencies (leto 0.41.0 and aequitas 0.2.0) for the Python wheel build process.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/python-release.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->