### PR TITLE
ci(python): Fix atlas-ref SHA to the published atlas head

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -20,12 +20,12 @@ jobs:
       attestations: write
       contents: write
       id-token: write
-    uses: ryancinsight/atlas/.github/workflows/python-wheels.yml@1a7cdcafce845bfa625e4917436c22566ad3486
+    uses: ryancinsight/atlas/.github/workflows/python-wheels.yml@1a7cdca7309f4a765b5bf644704521fa7c849208
     with:
       distribution: moirai-python
       import-name: moirai_python
       manifest-path: moirai-python/Cargo.toml
-      atlas-ref: 1a7cdcafce845bfa625e4917436c22566ad3486
+      atlas-ref: 1a7cdca7309f4a765b5bf644704521fa7c849208
       tag-prefix: moirai-python-v
       abi3: false
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'


### PR DESCRIPTION
Corrects the atlas-ref/uses pin from an invalid 40-char hash to the actual atlas main head 1a7cdca7309.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR corrects an invalid SHA reference in the Python release workflow by updating both the `uses` and `atlas-ref` parameters from an incomplete 39-character hash to the correct 40-character commit SHA (`1a7cdca7309f4a765b5bf644704521fa7c849208`) that points to the published atlas main head.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/python-release.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->